### PR TITLE
KSM 543 - Terraform: Remove sensitive information from logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,6 @@ require (
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d // indirect
-	google.golang.org/grpc v1.64.0 // indirect
+	google.golang.org/grpc v1.64.1 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d h1:k3zyW3BYYR30e8v3x0bTDdE9vpYFjZHK+HcyqkrppWk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
-google.golang.org/grpc v1.64.0 h1:KH3VH9y/MgNQg1dE7b3XfVK0GsPSIzJwdF617gUSbvY=
-google.golang.org/grpc v1.64.0/go.mod h1:oxjF8E3FBnjp+/gVFYdWacaLDx9na1aqy9oovLpxQYg=
+google.golang.org/grpc v1.64.1 h1:LKtvyfbX3UGVPFcGqJ9ItpVWW6oN/2XqTxfAnwRRXiA=
+google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvyjeP0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -83,7 +83,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	config := core.NewMemoryKeyValueStorage(creds)
 	if config.Get(core.KEY_APP_KEY) == "" || config.Get(core.KEY_CLIENT_ID) == "" || config.Get(core.KEY_PRIVATE_KEY) == "" {
-		return nil, diag.Errorf("bad credential: %s", creds)
+		maskedCred := strings.Repeat("*", min(100, len(creds)))
+		if len(maskedCred) >= 80 {
+			maskedCred += "..."
+		}
+		return nil, diag.Errorf("bad credential: %s", maskedCred)
 	}
 
 	client := core.NewSecretsManager(&core.ClientOptions{Config: config})


### PR DESCRIPTION
KSM 543 - Terraform: Remove sensitive information from logs
Bump [google.golang.org/grpc from 1.64.0 to 1.64.1](https://github.com/Keeper-Security/terraform-provider-secretsmanager/commit/6b040373d17d1c14269e1662dad8f1d32b0f3cd2)