### PR TITLE
Update docs to use v1.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ terraform {
     # add keeper secrets manager plugin
     secretsmanager = {
       source  = "keeper-security/secretsmanager"
-      version = ">= 1.0.0"
+      version = ">= 1.1.7"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     secretsmanager = {
       source = "keeper-security/secretsmanager"
-      version = ">= 1.1.5"
+      version = ">= 1.1.7"
     }
   }
 }


### PR DESCRIPTION
Updated some version numbers in the index and README to say 1.1.7 vs 1.0.0 or 1.1.5, etc.