### PR TITLE
KSM-527: Add support for PAM record types

### DIFF
--- a/secretsmanager/data_source_pam_database.go
+++ b/secretsmanager/data_source_pam_database.go
@@ -1,0 +1,100 @@
+package secretsmanager
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcePamDatabase() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePamDatabaseRead,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The path to PAM Database secret.",
+				ExactlyOneOf: []string{"path", "title"},
+			},
+			"title": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The title of PAM Database secret to search.",
+				ExactlyOneOf: []string{"path", "title"},
+			},
+			"folder_uid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The folder UID where the secret is stored.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret type.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret notes.",
+			},
+			// PAM Database specific fields
+			"pam_hostname":     schemaPamHostnameField(),
+			"use_ssl":          schemaCheckboxField(),
+			"login":            schemaLoginField(),
+			"password":         schemaPasswordField(""),
+			"rotation_scripts": schemaScriptField(),
+			"connect_database": schemaTextField(),
+			"database_id":      schemaTextField(),
+			"database_type":    schemaDatabaseTypeField(),
+			"provider_group":   schemaTextField(),
+			"provider_region":  schemaTextField(),
+			"file_ref":         schemaFileRefField(),
+			"totp":             schemaOneTimeCodeField(),
+		},
+	}
+}
+
+func dataSourcePamDatabaseRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	path := strings.TrimSpace(d.Get("path").(string))
+	title := strings.TrimSpace(d.Get("title").(string))
+	secret, err := getRecord(path, title, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceType := "pamDatabase"
+	recordType := secret.Type()
+	if recordType != dataSourceType {
+		return diag.Errorf("record type '%s' is not the expected type '%s' for this data source", recordType, dataSourceType)
+	}
+	if err = d.Set("type", recordType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("title", secret.Title()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("notes", secret.Notes()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("login", secret.GetFieldValueByType("login")); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("password", secret.GetFieldValueByType("password")); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fileItems := getFileItemsData(secret.Files)
+	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(path)
+
+	return diags
+}

--- a/secretsmanager/data_source_pam_machine.go
+++ b/secretsmanager/data_source_pam_machine.go
@@ -1,0 +1,100 @@
+package secretsmanager
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcePamMachine() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePamMachineRead,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The path to PAM Machine secret.",
+				ExactlyOneOf: []string{"path", "title"},
+			},
+			"title": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The title of PAM Machine secret to search.",
+				ExactlyOneOf: []string{"path", "title"},
+			},
+			"folder_uid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The folder UID where the secret is stored.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret type.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret notes.",
+			},
+			// PAM Machine specific fields
+			"pam_hostname":     schemaPamHostnameField(),
+			"login":            schemaLoginField(),
+			"password":         schemaPasswordField(""),
+			"rotation_scripts": schemaScriptField(),
+			"operating_system": schemaTextField(),
+			"ssl_verification": schemaCheckboxField(),
+			"instance_name":    schemaTextField(),
+			"instance_id":      schemaTextField(),
+			"provider_group":   schemaTextField(),
+			"provider_region":  schemaTextField(),
+			"file_ref":         schemaFileRefField(),
+			"totp":             schemaOneTimeCodeField(),
+		},
+	}
+}
+
+func dataSourcePamMachineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	path := strings.TrimSpace(d.Get("path").(string))
+	title := strings.TrimSpace(d.Get("title").(string))
+	secret, err := getRecord(path, title, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceType := "pamMachine"
+	recordType := secret.Type()
+	if recordType != dataSourceType {
+		return diag.Errorf("record type '%s' is not the expected type '%s' for this data source", recordType, dataSourceType)
+	}
+	if err = d.Set("type", recordType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("title", secret.Title()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("notes", secret.Notes()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("login", secret.GetFieldValueByType("login")); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("password", secret.GetFieldValueByType("password")); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fileItems := getFileItemsData(secret.Files)
+	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(path)
+
+	return diags
+}

--- a/secretsmanager/data_source_pam_user.go
+++ b/secretsmanager/data_source_pam_user.go
@@ -1,0 +1,96 @@
+package secretsmanager
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourcePamUser() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourcePamUserRead,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The path to PAM User secret.",
+				ExactlyOneOf: []string{"path", "title"},
+			},
+			"title": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The title of PAM User secret to search.",
+				ExactlyOneOf: []string{"path", "title"},
+			},
+			"folder_uid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The folder UID where the secret is stored.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret type.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret notes.",
+			},
+			// PAM User specific fields
+			"login":              schemaLoginField(),
+			"password":           schemaPasswordField(""),
+			"rotation_scripts":   schemaScriptField(),
+			"distinguished_name": schemaTextField(),
+			"connect_database":   schemaTextField(),
+			"managed":            schemaCheckboxField(),
+			"file_ref":           schemaFileRefField(),
+			"totp":               schemaOneTimeCodeField(),
+		},
+	}
+}
+
+func dataSourcePamUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	path := strings.TrimSpace(d.Get("path").(string))
+	title := strings.TrimSpace(d.Get("title").(string))
+	secret, err := getRecord(path, title, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	dataSourceType := "pamUser"
+	recordType := secret.Type()
+	if recordType != dataSourceType {
+		return diag.Errorf("record type '%s' is not the expected type '%s' for this data source", recordType, dataSourceType)
+	}
+	if err = d.Set("type", recordType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("title", secret.Title()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("notes", secret.Notes()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("login", secret.GetFieldValueByType("login")); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("password", secret.GetFieldValueByType("password")); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fileItems := getFileItemsData(secret.Files)
+	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(path)
+
+	return diags
+}

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -48,6 +48,9 @@ func Provider() *schema.Provider {
 			"secretsmanager_health_insurance":     dataSourceHealthInsurance(),
 			"secretsmanager_login":                dataSourceLogin(),
 			"secretsmanager_membership":           dataSourceMembership(),
+			"secretsmanager_pam_database":         dataSourcePamDatabase(),
+			"secretsmanager_pam_machine":          dataSourcePamMachine(),
+			"secretsmanager_pam_user":             dataSourcePamUser(),
 			"secretsmanager_passport":             dataSourcePassport(),
 			"secretsmanager_photo":                dataSourcePhoto(),
 			"secretsmanager_record":               dataSourceRecord(),
@@ -71,6 +74,9 @@ func Provider() *schema.Provider {
 			"secretsmanager_health_insurance":     resourceHealthInsurance(),
 			"secretsmanager_login":                resourceLogin(),
 			"secretsmanager_membership":           resourceMembership(),
+			"secretsmanager_pam_database":         resourcePamDatabase(),
+			"secretsmanager_pam_machine":          resourcePamMachine(),
+			"secretsmanager_pam_user":             resourcePamUser(),
 			"secretsmanager_passport":             resourcePassport(),
 			"secretsmanager_photo":                resourcePhoto(),
 			"secretsmanager_server_credentials":   resourceServerCredentials(),
@@ -120,34 +126,54 @@ type providerMeta struct {
 
 // map attribute names from schema to field types in record v3
 var mapSchemaToRecordFieldName map[string]string = map[string]string{
-	"account_number":    "accountNumber", // Text
-	"address":           "address",
-	"address_ref":       "addressRef",
-	"bank_account":      "bankAccount",
-	"birth_date":        "birthDate",
-	"card_ref":          "cardRef",
-	"company":           "text", // Text
-	"date":              "date",
-	"email":             "email",
-	"expiration_date":   "expirationDate",
-	"file_ref":          "fileRef",
-	"group_number":      "groupNumber", // Text
-	"host":              "host",
-	"key_pair":          "keyPair",
-	"license_number":    "licenseNumber",
-	"login":             "login",
-	"multiline":         "multiline",
-	"name":              "name",
-	"note":              "note", // SecureNote
-	"one_time_code":     "oneTimeCode",
-	"password":          "password",
-	"payment_card":      "paymentCard",
-	"phone":             "phone",
-	"pin_code":          "pinCode",
-	"secret":            "secret",
-	"security_question": "securityQuestion",
-	"text":              "text",
-	"title":             "title", // Text
+	"account_number":      "accountNumber", // Text
+	"address":             "address",
+	"address_ref":         "addressRef",
+	"bank_account":        "bankAccount",
+	"birth_date":          "birthDate",
+	"card_ref":            "cardRef",
+	"checkbox":            "checkbox",
+	"company":             "text", // Text
+	"connect_database":    "text", // Text with label
+	"database_id":         "text", // Text with label
+	"database_type":       "databaseType",
+	"date":                "date",
+	"directory_type":      "directoryType",
+	"distinguished_name":  "text", // Text with label
+	"email":               "email",
+	"expiration_date":     "expirationDate",
+	"file_ref":            "fileRef",
+	"group_number":        "groupNumber", // Text
+	"host":                "host",
+	"instance_id":         "text", // Text with label
+	"instance_name":       "text", // Text with label
+	"key_pair":            "keyPair",
+	"license_number":      "licenseNumber",
+	"login":               "login",
+	"managed":             "checkbox", // Checkbox with label
+	"multiline":           "multiline",
+	"name":                "name",
+	"note":                "note", // SecureNote
+	"one_time_code":       "oneTimeCode",
+	"operating_system":    "text", // Text with label
+	"pam_hostname":        "pamHostname",
+	"pam_resources":       "pamResources",
+	"password":            "password",
+	"payment_card":        "paymentCard",
+	"phone":               "phone",
+	"pin_code":            "pinCode",
+	"private_pem_key":     "secret", // Secret with label
+	"provider_group":      "text", // Text with label
+	"provider_region":     "text", // Text with label
+	"rotation_scripts":    "script", // Script with label
+	"schedule":            "schedule",
+	"script":              "script",
+	"secret":              "secret",
+	"security_question":   "securityQuestion",
+	"ssl_verification":    "checkbox", // Checkbox with label
+	"text":                "text",
+	"title":               "title", // Text
+	"use_ssl":             "checkbox", // Checkbox with label
 	"url":               "url",
 	// schema attributes that use field label instead of field type
 	// "company":            "text",          // contact
@@ -732,6 +758,132 @@ func getFieldResourceData(fieldType, section string, secret *core.Record) interf
 								}
 								if str, ok := fmap["answer"]; ok {
 									fv["answer"] = str
+								}
+							case "script":
+								if str, ok := fmap["fileRef"]; ok {
+									fv["file_ref"] = str
+								}
+								if str, ok := fmap["command"]; ok {
+									fv["command"] = str
+								}
+								if refs, ok := fmap["recordRef"]; ok {
+									if refList, ok := refs.([]interface{}); ok {
+										fv["record_ref"] = refList
+									}
+								}
+							case "pamHostname":
+								if str, ok := fmap["hostName"]; ok {
+									fv["hostname"] = str
+								}
+								if str, ok := fmap["port"]; ok {
+									fv["port"] = str
+								}
+							case "pamResources":
+								if str, ok := fmap["controllerUid"]; ok {
+									fv["controller_uid"] = str
+								}
+								if str, ok := fmap["folderUid"]; ok {
+									fv["folder_uid"] = str
+								}
+								if refs, ok := fmap["resourceRef"]; ok {
+									if refList, ok := refs.([]interface{}); ok {
+										fv["resource_ref"] = refList
+									}
+								}
+								if settings, ok := fmap["allowedSettings"]; ok {
+									if settingsMap, ok := settings.(map[string]interface{}); ok {
+										if val, ok := settingsMap["connections"]; ok {
+											fv["allowed_connections"] = val
+										}
+										if val, ok := settingsMap["portForwards"]; ok {
+											fv["allowed_port_forwards"] = val
+										}
+										if val, ok := settingsMap["rotation"]; ok {
+											fv["allowed_rotation"] = val
+										}
+										if val, ok := settingsMap["sessionRecording"]; ok {
+											fv["allowed_session_recording"] = val
+										}
+										if val, ok := settingsMap["typescriptRecording"]; ok {
+											fv["allowed_typescript_recording"] = val
+										}
+									}
+								}
+							default:
+								fv = nil
+							}
+							if len(fv) > 0 {
+								fis = append(fis, fv)
+							}
+						}
+					}
+				}
+				if len(fis) > 0 {
+					ftSchema["value"] = []interface{}{fis[0]}
+				}
+			}
+			return []interface{}{ftSchema}
+		}
+	}
+	return []interface{}{}
+}
+
+func getFieldResourceDataWithLabel(fieldType, section string, secret *core.Record, label string) interface{} {
+	if flds := getFieldDicts(fieldType, section, secret.RecordDict); len(flds) > 0 {
+		// Find the field with matching label
+		var matchingField interface{}
+		for _, fld := range flds {
+			if fldMap, ok := fld.(map[string]interface{}); ok {
+				if lblValue, found := fldMap["label"]; found && lblValue == label {
+					matchingField = fld
+					break
+				}
+			}
+		}
+		if matchingField == nil {
+			return []interface{}{}
+		}
+		if fieldSchema := parseFieldFromDataJson(matchingField); fieldSchema != nil {
+			ftSchema := map[string]interface{}{
+				"type": fieldType,
+			}
+			if _, found := fieldSchema.fields["label"]; found {
+				ftSchema["label"] = fieldSchema.Label
+			}
+			if _, found := fieldSchema.fields["required"]; found {
+				ftSchema["required"] = fieldSchema.Required
+			}
+			if _, found := fieldSchema.fields["privacyScreen"]; found {
+				ftSchema["privacy_screen"] = fieldSchema.PrivacyScreen
+			}
+			if _, found := fieldSchema.fields["value"]; found {
+				fis := []interface{}{}
+				if fi, ok := fieldSchema.Value.([]interface{}); ok {
+					for _, fiv := range fi {
+						if str, ok := fiv.(string); ok && str != "" {
+							// simple value - string
+							ftSchema["value"] = str
+						} else if num, ok := fiv.(float64); ok {
+							// simple value - Int64
+							ftSchema["value"] = int64(num)
+						} else if boolVal, ok := fiv.(bool); ok {
+							// simple value - bool
+							ftSchema["value"] = []interface{}{boolVal}
+						} else if fmap, ok := fiv.(map[string]interface{}); ok && len(fmap) > 0 {
+							// complex value - map struct fields to schema
+							fv := map[string]interface{}{}
+							switch fieldType {
+							case "script":
+								if str, ok := fmap["fileRef"]; ok {
+									fv["file_ref"] = str
+								}
+								if str, ok := fmap["command"]; ok {
+									fv["command"] = str
+								}
+								if refs, ok := fmap["recordRef"]; ok {
+									if refList, ok := refs.([]interface{}); ok {
+										fv["record_ref"] = refList
+									}
 								}
 							default:
 								fv = nil
@@ -1463,6 +1615,76 @@ func GetGenericFieldSchemaValue(fieldType string, field *genericFieldSchema) []i
 						securityQuestion.Answer = v.(string)
 					}
 					result = append(result, securityQuestion)
+				case "script":
+					script := core.Script{}
+					if v, found := msi["file_ref"]; found {
+						script.FileRef = v.(string)
+					}
+					if v, found := msi["command"]; found {
+						script.Command = v.(string)
+					}
+					if v, found := msi["record_ref"]; found {
+						if recordRefs, ok := v.([]interface{}); ok {
+							for _, ref := range recordRefs {
+								if refStr, ok := ref.(string); ok {
+									script.RecordRef = append(script.RecordRef, refStr)
+								}
+							}
+						}
+					}
+					result = append(result, script)
+				case "pamHostname":
+					host := core.Host{}
+					if v, found := msi["hostname"]; found {
+						host.Hostname = v.(string)
+					}
+					if v, found := msi["port"]; found {
+						host.Port = v.(string)
+					}
+					result = append(result, host)
+				case "pamResources":
+					pamResource := core.PamResource{}
+					if v, found := msi["controller_uid"]; found {
+						pamResource.ControllerUid = v.(string)
+					}
+					if v, found := msi["folder_uid"]; found {
+						pamResource.FolderUid = v.(string)
+					}
+					if v, found := msi["resource_ref"]; found {
+						if resourceRefs, ok := v.([]interface{}); ok {
+							for _, ref := range resourceRefs {
+								if refStr, ok := ref.(string); ok {
+									pamResource.ResourceRef = append(pamResource.ResourceRef, refStr)
+								}
+							}
+						}
+					}
+					if v, found := msi["allowed_connections"]; found {
+						if val, ok := v.(bool); ok {
+							pamResource.AllowedSettings.Connections = val
+						}
+					}
+					if v, found := msi["allowed_port_forwards"]; found {
+						if val, ok := v.(bool); ok {
+							pamResource.AllowedSettings.PortForwards = val
+						}
+					}
+					if v, found := msi["allowed_rotation"]; found {
+						if val, ok := v.(bool); ok {
+							pamResource.AllowedSettings.Rotation = val
+						}
+					}
+					if v, found := msi["allowed_session_recording"]; found {
+						if val, ok := v.(bool); ok {
+							pamResource.AllowedSettings.SessionRecording = val
+						}
+					}
+					if v, found := msi["allowed_typescript_recording"]; found {
+						if val, ok := v.(bool); ok {
+							pamResource.AllowedSettings.TypescriptRecording = val
+						}
+					}
+					result = append(result, pamResource)
 				}
 			}
 		}
@@ -1983,6 +2205,96 @@ func NewFieldFromSchema(fieldType string, fieldData interface{}) (newField inter
 			if _, found := data[0].fields["value"]; found {
 				if v, ok := GetGenericFieldSchemaValueString(data[0]); ok && v != "" {
 					field.Value = append(field.Value, v)
+				}
+			}
+			return field, nil
+		case "checkbox":
+			field := &core.Checkbox{KeeperRecordField: core.KeeperRecordField{Type: "checkbox"}}
+			if _, found := data[0].fields["label"]; found {
+				field.Label = data[0].Label
+			}
+			if _, found := data[0].fields["required"]; found {
+				field.Required = data[0].Required
+			}
+			if _, found := data[0].fields["value"]; found {
+				if v, ok := GetGenericFieldSchemaValueBool(data[0]); ok {
+					field.Value = append(field.Value, v)
+				}
+			}
+			return field, nil
+		case "script":
+			field := &core.Scripts{KeeperRecordField: core.KeeperRecordField{Type: "script"}}
+			if _, found := data[0].fields["label"]; found {
+				field.Label = data[0].Label
+			}
+			if _, found := data[0].fields["required"]; found {
+				field.Required = data[0].Required
+			}
+			if _, found := data[0].fields["privacy_screen"]; found {
+				field.PrivacyScreen = data[0].PrivacyScreen
+			}
+			if _, found := data[0].fields["value"]; found {
+				if v := GetGenericFieldSchemaValue(field.Type, data[0]); len(v) > 0 {
+					field.Value = append(field.Value, v[0].(core.Script))
+				}
+			}
+			return field, nil
+		case "pamHostname":
+			field := &core.PamHostname{KeeperRecordField: core.KeeperRecordField{Type: "pamHostname"}}
+			if _, found := data[0].fields["label"]; found {
+				field.Label = data[0].Label
+			}
+			if _, found := data[0].fields["required"]; found {
+				field.Required = data[0].Required
+			}
+			if _, found := data[0].fields["privacy_screen"]; found {
+				field.PrivacyScreen = data[0].PrivacyScreen
+			}
+			if _, found := data[0].fields["value"]; found {
+				if v := GetGenericFieldSchemaValue(field.Type, data[0]); len(v) > 0 {
+					field.Value = append(field.Value, v[0].(core.Host))
+				}
+			}
+			return field, nil
+		case "databaseType":
+			field := &core.DatabaseType{KeeperRecordField: core.KeeperRecordField{Type: "databaseType"}}
+			if _, found := data[0].fields["label"]; found {
+				field.Label = data[0].Label
+			}
+			if _, found := data[0].fields["required"]; found {
+				field.Required = data[0].Required
+			}
+			if _, found := data[0].fields["value"]; found {
+				if v, ok := GetGenericFieldSchemaValueString(data[0]); ok && v != "" {
+					field.Value = append(field.Value, v)
+				}
+			}
+			return field, nil
+		case "directoryType":
+			field := &core.DirectoryType{KeeperRecordField: core.KeeperRecordField{Type: "directoryType"}}
+			if _, found := data[0].fields["label"]; found {
+				field.Label = data[0].Label
+			}
+			if _, found := data[0].fields["required"]; found {
+				field.Required = data[0].Required
+			}
+			if _, found := data[0].fields["value"]; found {
+				if v, ok := GetGenericFieldSchemaValueString(data[0]); ok && v != "" {
+					field.Value = append(field.Value, v)
+				}
+			}
+			return field, nil
+		case "pamResources":
+			field := &core.PamResources{KeeperRecordField: core.KeeperRecordField{Type: "pamResources"}}
+			if _, found := data[0].fields["label"]; found {
+				field.Label = data[0].Label
+			}
+			if _, found := data[0].fields["required"]; found {
+				field.Required = data[0].Required
+			}
+			if _, found := data[0].fields["value"]; found {
+				if v := GetGenericFieldSchemaValue(field.Type, data[0]); len(v) > 0 {
+					field.Value = append(field.Value, v[0].(core.PamResource))
 				}
 			}
 			return field, nil

--- a/secretsmanager/record_fields_pam.go
+++ b/secretsmanager/record_fields_pam.go
@@ -1,0 +1,334 @@
+package secretsmanager
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// PAM-specific field schema functions
+
+func schemaCheckboxField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Checkbox field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Field value.",
+					Elem:        &schema.Schema{Type: schema.TypeBool},
+				},
+			},
+		},
+	}
+}
+
+func schemaScriptField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Script field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"privacy_screen": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Privacy screen flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "Script values.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"file_ref": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "File reference UID.",
+							},
+							"command": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Script command.",
+							},
+							"record_ref": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Description: "Record reference UIDs.",
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaPamHostnameField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "PAM Hostname field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"privacy_screen": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Privacy screen flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "Field value.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"hostname": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Hostname or IP address.",
+							},
+							"port": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Port number.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaPamResourcesField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "PAM Resources field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					Description: "PAM resource values.",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"controller_uid": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Controller UID.",
+							},
+							"folder_uid": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Folder UID.",
+							},
+							"resource_ref": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								Description: "Resource reference UIDs.",
+								Elem:        &schema.Schema{Type: schema.TypeString},
+							},
+							"allowed_connections": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Allow connections.",
+							},
+							"allowed_port_forwards": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Allow port forwards.",
+							},
+							"allowed_rotation": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Allow rotation.",
+							},
+							"allowed_session_recording": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Allow session recording.",
+							},
+							"allowed_typescript_recording": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Allow typescript recording.",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaDatabaseTypeField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Database type field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Database type value.",
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
+func schemaDirectoryTypeField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Directory type field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Directory type value.",
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}
+
+func schemaScheduleField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Description: "Schedule field data.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"field_type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type.",
+				},
+				"field_label": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Field label.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Required flag.",
+				},
+				"value": {
+					Type:        schema.TypeList,
+					Optional:    true,
+					MaxItems:    1,
+					Description: "Schedule value.",
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+}

--- a/secretsmanager/resource_pam_database.go
+++ b/secretsmanager/resource_pam_database.go
@@ -1,0 +1,504 @@
+package secretsmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+func resourcePamDatabase() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePamDatabaseCreate,
+		ReadContext:   resourcePamDatabaseRead,
+		UpdateContext: resourcePamDatabaseUpdate,
+		DeleteContext: resourcePamDatabaseDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePamDatabaseImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"folder_uid": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				AtLeastOneOf: []string{"folder_uid", "uid"},
+				Description:  "The folder UID where the secret is stored. The parent shared folder must be non empty.",
+			},
+			"uid": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"folder_uid", "uid"},
+				Description:  "The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret type.",
+			},
+			"title": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret title.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret notes.",
+			},
+			// PAM Database specific fields
+			"pam_hostname":     schemaPamHostnameField(),
+			"use_ssl":          schemaCheckboxField(),
+			"login":            schemaLoginField(),
+			"password":         schemaPasswordField(""),
+			"rotation_scripts": schemaScriptField(),
+			"connect_database": schemaTextField(),
+			"database_id":      schemaTextField(),
+			"database_type":    schemaDatabaseTypeField(),
+			"provider_group":   schemaTextField(),
+			"provider_region":  schemaTextField(),
+			"file_ref":         schemaFileRefField(),
+			"totp":             schemaOneTimeCodeField(),
+		},
+	}
+}
+
+func resourcePamDatabaseCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		uid = core.GenerateUid()
+	}
+	if validUid := validateUid(uid); !validUid {
+		return diag.Errorf("invalid UID format - use unpadded base64url encoded value (RFC 4648)")
+	}
+
+	folderUid := strings.TrimSpace(d.Get("folder_uid").(string))
+	if folderUid == "" {
+		return diag.Errorf("'folder_uid' is required to create new resource")
+	}
+
+	nrc := core.NewRecordCreate("pamDatabase", "")
+	if title := d.Get("title"); title != nil && title.(string) != "" {
+		nrc.Title = title.(string)
+	}
+	if notes := d.Get("notes"); notes != nil && notes.(string) != "" {
+		nrc.Notes = notes.(string)
+	}
+
+	if fieldData := d.Get("pam_hostname"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("pamHostname", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "pam_hostname", "pamHostname"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("use_ssl"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("checkbox", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Checkbox).Label = "Use SSL"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "use_ssl", "checkbox"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("login"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("login", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "login", "login"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("password"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("password", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			if generated, err := applyGeneratePassword(fieldData, field); err != nil {
+				return diag.FromErr(err)
+			} else if generated {
+				if err := d.Set("password", fieldData); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "password", "password"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("rotation_scripts"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("script", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Scripts).Label = "Rotation Scripts"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "rotation_scripts", "script"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("connect_database"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Connect Database"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "connect_database", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("database_id"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Database Id"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "database_id", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("database_type"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("databaseType", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "database_type", "databaseType"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("provider_group"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Provider Group"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "provider_group", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("provider_region"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Provider Region"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "provider_region", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("totp"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("oneTimeCode", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "totp", "oneTimeCode"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("file_ref"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("fileRef", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if folderUid == "*" {
+		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
+			return diag.FromErr(err)
+		} else {
+			folderUid = fuid
+		}
+	} else {
+		folderUid = folderUid
+	}
+
+	if _, err := createRecord(uid, folderUid, nrc, client); err != nil {
+		return diag.FromErr(err)
+	} else {
+		d.SetId(uid)
+		resourcePamDatabaseRead(ctx, d, m)
+	}
+
+	return diags
+}
+
+func resourcePamDatabaseRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	title := strings.TrimSpace(d.Get("title").(string))
+	if uid == "" && title == "" {
+		return diag.Errorf("record UID and/or title required to locate the record")
+	}
+
+	secret, err := getRecord(uid, title, client)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "record not found") {
+			d.SetId("")
+			return diags
+		}
+		return diag.FromErr(err)
+	}
+
+	resourceType := "pamDatabase"
+	recordType := secret.Type()
+	if recordType != resourceType {
+		return diag.Errorf("record type '%s' is not the expected type '%s' for this resource", recordType, resourceType)
+	}
+	if uid == "" {
+		if err = d.Set("uid", secret.Uid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	fuid := secret.InnerFolderUid()
+	if fuid == "" {
+		fuid = secret.FolderUid()
+	}
+	if fuid != "" {
+		if err = d.Set("folder_uid", fuid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err = d.Set("type", recordType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("title", secret.Title()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("notes", secret.Notes()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	login := getFieldResourceData("login", "fields", secret)
+	if err = d.Set("login", login); err != nil {
+		return diag.FromErr(err)
+	}
+	password := getFieldResourceData("password", "fields", secret)
+	mergePassword(d.Get("password"), password)
+	if err = d.Set("password", password); err != nil {
+		return diag.FromErr(err)
+	}
+	oneTimeCode := getFieldResourceData("oneTimeCode", "fields", secret)
+	if err = d.Set("totp", oneTimeCode); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// PAM Database specific fields
+	pamHostname := getFieldResourceData("pamHostname", "fields", secret)
+	if err = d.Set("pam_hostname", pamHostname); err != nil {
+		return diag.FromErr(err)
+	}
+	useSSL := getFieldResourceDataWithLabel("checkbox", "fields", secret, "Use SSL")
+	if err = d.Set("use_ssl", useSSL); err != nil {
+		return diag.FromErr(err)
+	}
+	rotationScripts := getFieldResourceDataWithLabel("script", "fields", secret, "Rotation Scripts")
+	if err = d.Set("rotation_scripts", rotationScripts); err != nil {
+		return diag.FromErr(err)
+	}
+	connectDatabase := getFieldResourceDataWithLabel("text", "fields", secret, "Connect Database")
+	if err = d.Set("connect_database", connectDatabase); err != nil {
+		return diag.FromErr(err)
+	}
+	databaseId := getFieldResourceDataWithLabel("text", "fields", secret, "Database Id")
+	if err = d.Set("database_id", databaseId); err != nil {
+		return diag.FromErr(err)
+	}
+	databaseType := getFieldResourceData("databaseType", "fields", secret)
+	if err = d.Set("database_type", databaseType); err != nil {
+		return diag.FromErr(err)
+	}
+	providerGroup := getFieldResourceDataWithLabel("text", "fields", secret, "Provider Group")
+	if err = d.Set("provider_group", providerGroup); err != nil {
+		return diag.FromErr(err)
+	}
+	providerRegion := getFieldResourceDataWithLabel("text", "fields", secret, "Provider Region")
+	if err = d.Set("provider_region", providerRegion); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fileItems := getFileItemsResourceData(secret)
+	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uid)
+	return diags
+}
+
+func resourcePamDatabaseUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		return diag.Errorf("'uid' is required to update existing resource")
+	}
+
+	hasRestrictedChanges := d.HasChange("folder_uid") || d.HasChange("uid") || d.HasChange("type")
+	if hasRestrictedChanges {
+		return diag.Errorf("changes to folder_uid, uid, and type are not allowed")
+	}
+
+	title := strings.TrimSpace(d.Get("title").(string))
+	secret, err := getRecord(uid, title, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChange("title") {
+		secret.SetTitle(d.Get("title").(string))
+	}
+	if d.HasChange("notes") {
+		secret.SetNotes(d.Get("notes").(string))
+	}
+
+	if d.HasChange("login") {
+		if _, err := ApplyFieldChange("fields", "login", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("password") {
+		if _, err := ApplyFieldChange("fields", "password", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("pam_hostname") {
+		if _, err := ApplyFieldChange("fields", "pam_hostname", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("use_ssl") {
+		if _, err := ApplyFieldChange("fields", "use_ssl", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("rotation_scripts") {
+		if _, err := ApplyFieldChange("fields", "rotation_scripts", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("connect_database") {
+		if _, err := ApplyFieldChange("fields", "connect_database", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("database_id") {
+		if _, err := ApplyFieldChange("fields", "database_id", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("database_type") {
+		if _, err := ApplyFieldChange("fields", "database_type", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("provider_group") {
+		if _, err := ApplyFieldChange("fields", "provider_group", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("provider_region") {
+		if _, err := ApplyFieldChange("fields", "provider_region", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("totp") {
+		if _, err := ApplyFieldChange("fields", "totp", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("file_ref") {
+		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if err := saveRecord(secret, client); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourcePamDatabaseRead(ctx, d, m)
+}
+
+func resourcePamDatabaseDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		return diag.Errorf("'uid' is required to delete existing resource")
+	}
+
+	if err := deleteRecord(uid, client); err != nil {
+		if strings.HasSuffix(err.Error(), "unexpected status: ''") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Record UID: %s not found - probably already deleted (externally)", uid),
+				Detail: fmt.Sprintf("Delete record UID: %s returned empty status."+
+					" That usually means the record doesn't exist -"+
+					" either already deleted (externally),"+
+					" or no longer shared to the corresponding KSM Application.", uid),
+			})
+		} else {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId("")
+	return diags
+}
+func resourcePamDatabaseImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	uid := d.Id()
+	if strings.TrimSpace(uid) == "" {
+		return nil, errors.New("'uid' is required to import resource")
+	}
+
+	if err := d.Set("uid", uid); err != nil {
+		return nil, err
+	}
+
+	diags := resourcePamDatabaseRead(ctx, d, m)
+	if diags.HasError() {
+		for _, d := range diags {
+			if d.Severity == diag.Error {
+				return nil, fmt.Errorf("error reading PAM Database: %s", d.Summary)
+			}
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/secretsmanager/resource_pam_machine.go
+++ b/secretsmanager/resource_pam_machine.go
@@ -1,0 +1,505 @@
+package secretsmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+func resourcePamMachine() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePamMachineCreate,
+		ReadContext:   resourcePamMachineRead,
+		UpdateContext: resourcePamMachineUpdate,
+		DeleteContext: resourcePamMachineDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePamMachineImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"folder_uid": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				AtLeastOneOf: []string{"folder_uid", "uid"},
+				Description:  "The folder UID where the secret is stored. The parent shared folder must be non empty.",
+			},
+			"uid": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"folder_uid", "uid"},
+				Description:  "The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret type.",
+			},
+			"title": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret title.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret notes.",
+			},
+			// PAM Machine specific fields
+			"pam_hostname":     schemaPamHostnameField(),
+			"login":            schemaLoginField(),
+			"password":         schemaPasswordField(""),
+			"rotation_scripts": schemaScriptField(),
+			"operating_system": schemaTextField(),
+			"ssl_verification": schemaCheckboxField(),
+			"instance_name":    schemaTextField(),
+			"instance_id":      schemaTextField(),
+			"provider_group":   schemaTextField(),
+			"provider_region":  schemaTextField(),
+			"file_ref":         schemaFileRefField(),
+			"totp":             schemaOneTimeCodeField(),
+		},
+	}
+}
+
+func resourcePamMachineCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		uid = core.GenerateUid()
+	}
+	if validUid := validateUid(uid); !validUid {
+		return diag.Errorf("invalid UID format - use unpadded base64url encoded value (RFC 4648)")
+	}
+
+	folderUid := strings.TrimSpace(d.Get("folder_uid").(string))
+	if folderUid == "" {
+		return diag.Errorf("'folder_uid' is required to create new resource")
+	}
+
+	nrc := core.NewRecordCreate("pamMachine", "")
+	if title := d.Get("title"); title != nil && title.(string) != "" {
+		nrc.Title = title.(string)
+	}
+	if notes := d.Get("notes"); notes != nil && notes.(string) != "" {
+		nrc.Notes = notes.(string)
+	}
+
+	if fieldData := d.Get("pam_hostname"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("pamHostname", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "pam_hostname", "pamHostname"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("login"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("login", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "login", "login"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("password"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("password", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			if generated, err := applyGeneratePassword(fieldData, field); err != nil {
+				return diag.FromErr(err)
+			} else if generated {
+				if err := d.Set("password", fieldData); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "password", "password"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("rotation_scripts"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("script", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Scripts).Label = "Rotation Scripts"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "rotation_scripts", "script"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("operating_system"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Operating System"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "operating_system", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("ssl_verification"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("checkbox", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Checkbox).Label = "SSL Verification"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "ssl_verification", "checkbox"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("instance_name"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Instance Name"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "instance_name", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("instance_id"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Instance Id"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "instance_id", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("provider_group"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Provider Group"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "provider_group", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("provider_region"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Provider Region"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "provider_region", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("totp"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("oneTimeCode", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "totp", "oneTimeCode"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("file_ref"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("fileRef", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if folderUid == "*" {
+		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
+			return diag.FromErr(err)
+		} else {
+			folderUid = fuid
+		}
+	} else {
+		folderUid = folderUid
+	}
+
+	if _, err := createRecord(uid, folderUid, nrc, client); err != nil {
+		return diag.FromErr(err)
+	} else {
+		d.SetId(uid)
+		resourcePamMachineRead(ctx, d, m)
+	}
+
+	return diags
+}
+
+func resourcePamMachineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	title := strings.TrimSpace(d.Get("title").(string))
+	if uid == "" && title == "" {
+		return diag.Errorf("record UID and/or title required to locate the record")
+	}
+
+	secret, err := getRecord(uid, title, client)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "record not found") {
+			d.SetId("")
+			return diags
+		}
+		return diag.FromErr(err)
+	}
+
+	resourceType := "pamMachine"
+	recordType := secret.Type()
+	if recordType != resourceType {
+		return diag.Errorf("record type '%s' is not the expected type '%s' for this resource", recordType, resourceType)
+	}
+	if uid == "" {
+		if err = d.Set("uid", secret.Uid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	fuid := secret.InnerFolderUid()
+	if fuid == "" {
+		fuid = secret.FolderUid()
+	}
+	if fuid != "" {
+		if err = d.Set("folder_uid", fuid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err = d.Set("type", recordType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("title", secret.Title()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("notes", secret.Notes()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	login := getFieldResourceData("login", "fields", secret)
+	if err = d.Set("login", login); err != nil {
+		return diag.FromErr(err)
+	}
+	password := getFieldResourceData("password", "fields", secret)
+	mergePassword(d.Get("password"), password)
+	if err = d.Set("password", password); err != nil {
+		return diag.FromErr(err)
+	}
+	oneTimeCode := getFieldResourceData("oneTimeCode", "fields", secret)
+	if err = d.Set("totp", oneTimeCode); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// PAM Machine specific fields
+	pamHostname := getFieldResourceData("pamHostname", "fields", secret)
+	if err = d.Set("pam_hostname", pamHostname); err != nil {
+		return diag.FromErr(err)
+	}
+	rotationScripts := getFieldResourceDataWithLabel("script", "fields", secret, "Rotation Scripts")
+	if err = d.Set("rotation_scripts", rotationScripts); err != nil {
+		return diag.FromErr(err)
+	}
+	operatingSystem := getFieldResourceDataWithLabel("text", "fields", secret, "Operating System")
+	if err = d.Set("operating_system", operatingSystem); err != nil {
+		return diag.FromErr(err)
+	}
+	sslVerification := getFieldResourceDataWithLabel("checkbox", "fields", secret, "SSL Verification")
+	if err = d.Set("ssl_verification", sslVerification); err != nil {
+		return diag.FromErr(err)
+	}
+	instanceName := getFieldResourceDataWithLabel("text", "fields", secret, "Instance Name")
+	if err = d.Set("instance_name", instanceName); err != nil {
+		return diag.FromErr(err)
+	}
+	instanceId := getFieldResourceDataWithLabel("text", "fields", secret, "Instance Id")
+	if err = d.Set("instance_id", instanceId); err != nil {
+		return diag.FromErr(err)
+	}
+	providerGroup := getFieldResourceDataWithLabel("text", "fields", secret, "Provider Group")
+	if err = d.Set("provider_group", providerGroup); err != nil {
+		return diag.FromErr(err)
+	}
+	providerRegion := getFieldResourceDataWithLabel("text", "fields", secret, "Provider Region")
+	if err = d.Set("provider_region", providerRegion); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fileItems := getFileItemsResourceData(secret)
+	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uid)
+	return diags
+}
+
+func resourcePamMachineUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		return diag.Errorf("'uid' is required to update existing resource")
+	}
+
+	hasRestrictedChanges := d.HasChange("folder_uid") || d.HasChange("uid") || d.HasChange("type")
+	if hasRestrictedChanges {
+		return diag.Errorf("changes to folder_uid, uid, and type are not allowed")
+	}
+
+	title := strings.TrimSpace(d.Get("title").(string))
+	secret, err := getRecord(uid, title, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChange("title") {
+		secret.SetTitle(d.Get("title").(string))
+	}
+	if d.HasChange("notes") {
+		secret.SetNotes(d.Get("notes").(string))
+	}
+
+	if d.HasChange("login") {
+		if _, err := ApplyFieldChange("fields", "login", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("password") {
+		if _, err := ApplyFieldChange("fields", "password", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("pam_hostname") {
+		if _, err := ApplyFieldChange("fields", "pam_hostname", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("rotation_scripts") {
+		if _, err := ApplyFieldChange("fields", "rotation_scripts", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("operating_system") {
+		if _, err := ApplyFieldChange("fields", "operating_system", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("ssl_verification") {
+		if _, err := ApplyFieldChange("fields", "ssl_verification", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("instance_name") {
+		if _, err := ApplyFieldChange("fields", "instance_name", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("instance_id") {
+		if _, err := ApplyFieldChange("fields", "instance_id", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("provider_group") {
+		if _, err := ApplyFieldChange("fields", "provider_group", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("provider_region") {
+		if _, err := ApplyFieldChange("fields", "provider_region", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("totp") {
+		if _, err := ApplyFieldChange("fields", "totp", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("file_ref") {
+		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if err := saveRecord(secret, client); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourcePamMachineRead(ctx, d, m)
+}
+
+func resourcePamMachineDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		return diag.Errorf("'uid' is required to delete existing resource")
+	}
+
+	if err := deleteRecord(uid, client); err != nil {
+		if strings.HasSuffix(err.Error(), "unexpected status: ''") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Record UID: %s not found - probably already deleted (externally)", uid),
+				Detail: fmt.Sprintf("Delete record UID: %s returned empty status."+
+					" That usually means the record doesn't exist -"+
+					" either already deleted (externally),"+
+					" or no longer shared to the corresponding KSM Application.", uid),
+			})
+		} else {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId("")
+	return diags
+}
+func resourcePamMachineImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	uid := d.Id()
+	if strings.TrimSpace(uid) == "" {
+		return nil, errors.New("'uid' is required to import resource")
+	}
+
+	if err := d.Set("uid", uid); err != nil {
+		return nil, err
+	}
+
+	diags := resourcePamMachineRead(ctx, d, m)
+	if diags.HasError() {
+		for _, d := range diags {
+			if d.Severity == diag.Error {
+				return nil, fmt.Errorf("error reading PAM Machine: %s", d.Summary)
+			}
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/secretsmanager/resource_pam_user.go
+++ b/secretsmanager/resource_pam_user.go
@@ -1,0 +1,436 @@
+package secretsmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+func resourcePamUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourcePamUserCreate,
+		ReadContext:   resourcePamUserRead,
+		UpdateContext: resourcePamUserUpdate,
+		DeleteContext: resourcePamUserDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePamUserImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"folder_uid": {
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				AtLeastOneOf: []string{"folder_uid", "uid"},
+				Description:  "The folder UID where the secret is stored. The parent shared folder must be non empty.",
+			},
+			"uid": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"folder_uid", "uid"},
+				Description:  "The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret type.",
+			},
+			"title": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret title.",
+			},
+			"notes": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The secret notes.",
+			},
+			// PAM User specific fields
+			"login":              schemaLoginField(),
+			"password":           schemaPasswordField(""),
+			"rotation_scripts":   schemaScriptField(),
+			"distinguished_name": schemaTextField(),
+			"connect_database":   schemaTextField(),
+			"managed":            schemaCheckboxField(),
+			"file_ref":           schemaFileRefField(),
+			"totp":               schemaOneTimeCodeField(),
+		},
+	}
+}
+
+func resourcePamUserCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		uid = core.GenerateUid()
+	}
+	if validUid := validateUid(uid); !validUid {
+		return diag.Errorf("invalid UID format - use unpadded base64url encoded value (RFC 4648)")
+	}
+
+	folderUid := strings.TrimSpace(d.Get("folder_uid").(string))
+	if folderUid == "" {
+		return diag.Errorf("'folder_uid' is required to create new resource")
+	}
+
+	nrc := core.NewRecordCreate("pamUser", "")
+	if title := d.Get("title"); title != nil && title.(string) != "" {
+		nrc.Title = title.(string)
+	}
+	if notes := d.Get("notes"); notes != nil && notes.(string) != "" {
+		nrc.Notes = notes.(string)
+	}
+
+	if fieldData := d.Get("login"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("login", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "login", "login"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if fieldData := d.Get("password"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("password", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			if generated, err := applyGeneratePassword(fieldData, field); err != nil {
+				return diag.FromErr(err)
+			} else if generated {
+				if err := d.Set("password", fieldData); err != nil {
+					return diag.FromErr(err)
+				}
+			}
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "password", "password"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("rotation_scripts"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("script", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Scripts).Label = "Rotation Scripts"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "rotation_scripts", "script"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("distinguished_name"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Distinguished Name"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "distinguished_name", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("connect_database"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("text", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Text).Label = "Connect Database"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "connect_database", "text"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("managed"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("checkbox", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			field.(*core.Checkbox).Label = "Managed"
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "managed", "checkbox"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("totp"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("oneTimeCode", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "totp", "oneTimeCode"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if fieldData := d.Get("file_ref"); fieldData != nil && len(fieldData.([]interface{})) > 0 {
+		if field, err := NewFieldFromSchema("fileRef", fieldData); err != nil {
+			return diag.FromErr(err)
+		} else if field != nil {
+			nrc.Fields = append(nrc.Fields, field)
+			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	if folderUid == "*" {
+		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
+			return diag.FromErr(err)
+		} else {
+			folderUid = fuid
+		}
+	}
+	uid, err := createRecord(uid, folderUid, nrc, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if fuid := strings.TrimSpace(d.Get("folder_uid").(string)); fuid == "*" {
+		if err = d.Set("folder_uid", folderUid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err = d.Set("uid", uid); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("type", "pamUser"); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uid)
+	return diags
+}
+
+func resourcePamUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	title := strings.TrimSpace(d.Get("title").(string))
+	if uid == "" && title == "" {
+		return diag.Errorf("record UID and/or title required to locate the record")
+	}
+
+	secret, err := getRecord(uid, title, client)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "record not found") {
+			d.SetId("")
+			return diags
+		}
+		return diag.FromErr(err)
+	}
+
+	resourceType := "pamUser"
+	recordType := secret.Type()
+	if recordType != resourceType {
+		return diag.Errorf("record type '%s' is not the expected type '%s' for this resource", recordType, resourceType)
+	}
+	if uid == "" {
+		if err = d.Set("uid", secret.Uid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	fuid := secret.InnerFolderUid()
+	if fuid == "" {
+		fuid = secret.FolderUid()
+	}
+	if fuid != "" {
+		if err = d.Set("folder_uid", fuid); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if err = d.Set("type", recordType); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("title", secret.Title()); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("notes", secret.Notes()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	login := getFieldResourceData("login", "fields", secret)
+	if err = d.Set("login", login); err != nil {
+		return diag.FromErr(err)
+	}
+	password := getFieldResourceData("password", "fields", secret)
+	mergePassword(d.Get("password"), password)
+	if err = d.Set("password", password); err != nil {
+		return diag.FromErr(err)
+	}
+	oneTimeCode := getFieldResourceData("oneTimeCode", "fields", secret)
+	if err = d.Set("totp", oneTimeCode); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// PAM-specific fields
+	rotationScripts := getFieldResourceDataWithLabel("script", "fields", secret, "Rotation Scripts")
+	if err = d.Set("rotation_scripts", rotationScripts); err != nil {
+		return diag.FromErr(err)
+	}
+	distinguishedName := getFieldResourceDataWithLabel("text", "fields", secret, "Distinguished Name")
+	if err = d.Set("distinguished_name", distinguishedName); err != nil {
+		return diag.FromErr(err)
+	}
+	connectDatabase := getFieldResourceDataWithLabel("text", "fields", secret, "Connect Database")
+	if err = d.Set("connect_database", connectDatabase); err != nil {
+		return diag.FromErr(err)
+	}
+	managed := getFieldResourceDataWithLabel("checkbox", "fields", secret, "Managed")
+	if err = d.Set("managed", managed); err != nil {
+		return diag.FromErr(err)
+	}
+
+	fileItems := getFileItemsResourceData(secret)
+	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uid)
+	return diags
+}
+
+func resourcePamUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		return diag.Errorf("'uid' is required to update existing resource")
+	}
+
+	hasRestrictedChanges := d.HasChange("folder_uid") || d.HasChange("uid") || d.HasChange("type")
+	if hasRestrictedChanges {
+		return diag.Errorf("changes to folder_uid, uid, and type are not allowed")
+	}
+
+	title := strings.TrimSpace(d.Get("title").(string))
+	secret, err := getRecord(uid, title, client)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if d.HasChange("title") {
+		secret.SetTitle(d.Get("title").(string))
+	}
+	if d.HasChange("notes") {
+		secret.SetNotes(d.Get("notes").(string))
+	}
+
+	if d.HasChange("login") {
+		if _, err := ApplyFieldChange("fields", "login", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("password") {
+		if _, err := ApplyFieldChange("fields", "password", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("rotation_scripts") {
+		if _, err := ApplyFieldChange("fields", "rotation_scripts", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("distinguished_name") {
+		if _, err := ApplyFieldChange("fields", "distinguished_name", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("connect_database") {
+		if _, err := ApplyFieldChange("fields", "connect_database", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("managed") {
+		if _, err := ApplyFieldChange("fields", "managed", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if d.HasChange("totp") {
+		if _, err := ApplyFieldChange("fields", "totp", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("file_ref") {
+		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if err := saveRecord(secret, client); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uid)
+	return diags
+}
+
+func resourcePamUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	provider := m.(providerMeta)
+	client := *provider.client
+	var diags diag.Diagnostics
+
+	uid := strings.TrimSpace(d.Get("uid").(string))
+	if uid == "" {
+		return diag.Errorf("'uid' is required to delete existing resource")
+	}
+
+	if err := deleteRecord(uid, client); err != nil {
+		if strings.HasSuffix(err.Error(), "unexpected status: ''") {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Record UID: %s not found - probably already deleted (externally)", uid),
+				Detail: fmt.Sprintf("Delete record UID: %s returned empty status."+
+					" That usually means the record doesn't exist -"+
+					" either already deleted (externally),"+
+					" or no longer shared to the corresponding KSM Application.", uid),
+			})
+		} else {
+			return diag.FromErr(err)
+		}
+	}
+
+	d.SetId("")
+	return diags
+}
+
+func resourcePamUserImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	uid := d.Id()
+	if strings.TrimSpace(uid) == "" {
+		return nil, errors.New("'uid' is required to import resource")
+	}
+
+	if err := d.Set("uid", uid); err != nil {
+		return nil, err
+	}
+
+	diags := resourcePamUserRead(ctx, d, m)
+	if diags.HasError() {
+		for _, d := range diags {
+			if d.Severity == diag.Error {
+				return nil, fmt.Errorf("error reading PAM User: %s", d.Summary)
+			}
+		}
+	}
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
Implemented comprehensive PAM (Privileged Access Management) record type support:
- PAM User: secretsmanager_pam_user resource and data source
- PAM Machine: secretsmanager_pam_machine resource and data source
- PAM Database: secretsmanager_pam_database resource and data source

New PAM-specific field types:
- pamHostname: hostname/port configuration
- checkbox: boolean checkbox fields
- script: script execution with file/command references
- databaseType: database type selector
- directoryType: directory type selector
- schedule: rotation schedule configuration
- pamResources: PAM resource references

All implementations follow existing Terraform provider patterns and are based on KSM SDK specifications.