### PR TITLE
fix(KSM-871): data source fix, missing tests, and comprehensive test coverage

### DIFF
--- a/examples/ephemeral-resources/pam_remote_browser.tf
+++ b/examples/ephemeral-resources/pam_remote_browser.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    secretsmanager = {
+      source  = "keeper-security/secretsmanager"
+      version = ">= 1.3.0"
+    }
+  }
+}
+
+provider "secretsmanager" {
+  # credential = "<CREDENTIAL>"
+  # can also be set via KEEPER_CREDENTIAL env variable
+}
+
+# Read a PAM Remote Browser record as ephemeral (never stored in state)
+ephemeral "secretsmanager_pam_remote_browser" "browser" {
+  path = "<record UID>"
+}

--- a/secretsmanager/data_source_pam_remote_browser.go
+++ b/secretsmanager/data_source_pam_remote_browser.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourcePamRemoteBrowser() *schema.Resource {
@@ -43,11 +42,9 @@ func dataSourcePamRemoteBrowser() *schema.Resource {
 			// PAM Remote Browser specific fields
 			"rbi_url": schemaTextField(),
 			"pam_remote_browser_settings": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: suppressEquivalentJSON,
-				Description:      "PAM Remote Browser connection settings as JSON string.",
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "PAM Remote Browser connection settings as JSON string.",
 			},
 			"traffic_encryption_seed": schemaTextField(),
 			"file_ref":                schemaFileRefField(),

--- a/secretsmanager/data_source_pam_remote_browser_test.go
+++ b/secretsmanager/data_source_pam_remote_browser_test.go
@@ -1,0 +1,50 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+func TestAccDataSourcePamRemoteBrowser(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_rb_datasource"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_remote_browser" "%v" {
+			folder_uid = "%v"
+			uid = "%v"
+			title = "%v"
+			notes = "%v"
+			rbi_url {
+				value = "https://test-rbi.example.com"
+			}
+		}
+
+		data "secretsmanager_pam_remote_browser" "%v" {
+			path = secretsmanager_pam_remote_browser.%v.uid
+		}
+	`, secretTitle, secretFolderUid, secretUid, secretTitle, secretTitle, secretTitle, secretTitle)
+
+	dataSourceName := fmt.Sprintf("data.secretsmanager_pam_remote_browser.%v", secretTitle)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "pamRemoteBrowser"),
+					resource.TestCheckResourceAttr(dataSourceName, "title", secretTitle),
+					resource.TestCheckResourceAttr(dataSourceName, "notes", secretTitle),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_field_test.go
+++ b/secretsmanager/ephemeral_field_test.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,6 +28,50 @@ func TestAccEphemeralField(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccEphemeralFieldByTitle(t *testing.T) {
+	secretType := "field"
+	_, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_field" "%v" {
+			path = "*/field/login"
+			title = "%v"
+		}
+	`, secretTitle, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccEphemeralFieldInvalidPath(t *testing.T) {
+	config := `
+		ephemeral "secretsmanager_field" "bad" {
+			path = "NONEXISTENT_UID_12345/field/login"
+		}
+	`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Error reading field`),
 			},
 		},
 	})

--- a/secretsmanager/ephemeral_login_test.go
+++ b/secretsmanager/ephemeral_login_test.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -52,6 +53,32 @@ func TestAccEphemeralLoginByTitle(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccEphemeralLoginWrongType(t *testing.T) {
+	// Use a bankCard record UID with the login ephemeral resource — should error
+	secretUid, secretTitle := testAcc.getRecordInfo("bankCard")
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing bankCard UID and/or Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_login" "wrong_type" {
+			path = "%v"
+			title = "%v"
+		}
+	`, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Record Type Mismatch`),
 			},
 		},
 	})

--- a/secretsmanager/ephemeral_pam_database_test.go
+++ b/secretsmanager/ephemeral_pam_database_test.go
@@ -1,0 +1,33 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEphemeralUpamUdatabase(t *testing.T) {
+	secretType := "pamDatabase"
+	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_pam_database" "%v" {
+			path = "%v"
+			title = "%v"
+		}
+	`, secretTitle, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_pam_directory_test.go
+++ b/secretsmanager/ephemeral_pam_directory_test.go
@@ -1,0 +1,33 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEphemeralUpamUdirectory(t *testing.T) {
+	secretType := "pamDirectory"
+	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_pam_directory" "%v" {
+			path = "%v"
+			title = "%v"
+		}
+	`, secretTitle, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_pam_machine_test.go
+++ b/secretsmanager/ephemeral_pam_machine_test.go
@@ -1,0 +1,33 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEphemeralUpamUmachine(t *testing.T) {
+	secretType := "pamMachine"
+	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_pam_machine" "%v" {
+			path = "%v"
+			title = "%v"
+		}
+	`, secretTitle, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_pam_remote_browser_test.go
+++ b/secretsmanager/ephemeral_pam_remote_browser_test.go
@@ -1,0 +1,33 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEphemeralUpamUremoteUbrowser(t *testing.T) {
+	secretType := "pamRemoteBrowser"
+	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_pam_remote_browser" "%v" {
+			path = "%v"
+			title = "%v"
+		}
+	`, secretTitle, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_pam_user_test.go
+++ b/secretsmanager/ephemeral_pam_user_test.go
@@ -1,0 +1,33 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEphemeralUpamUuser(t *testing.T) {
+	secretType := "pamUser"
+	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_pam_user" "%v" {
+			path = "%v"
+			title = "%v"
+		}
+	`, secretTitle, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_record_test.go
+++ b/secretsmanager/ephemeral_record_test.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,6 +28,50 @@ func TestAccEphemeralRecord(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccEphemeralRecordByTitle(t *testing.T) {
+	secretType := "login"
+	_, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret Title")
+	}
+
+	config := fmt.Sprintf(`
+		ephemeral "secretsmanager_record" "%v" {
+			path = "*"
+			title = "%v"
+		}
+	`, secretTitle, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+		},
+	})
+}
+
+func TestAccEphemeralRecordInvalidPath(t *testing.T) {
+	config := `
+		ephemeral "secretsmanager_record" "bad" {
+			path = "NONEXISTENT_UID_XXXXX"
+		}
+	`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Error reading secret`),
 			},
 		},
 	})

--- a/secretsmanager/resource_pam_remote_browser_test.go
+++ b/secretsmanager/resource_pam_remote_browser_test.go
@@ -1,0 +1,124 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+func TestAccResourcePamRemoteBrowser_create(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_remote_browser_create"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_remote_browser" "%v" {
+			folder_uid = "%v"
+			uid = "%v"
+			title = "%v"
+			notes = "%v"
+			rbi_url {
+				value = "https://internal-app.example.com"
+			}
+		}
+	`, secretTitle, secretFolderUid, secretUid, secretTitle, secretTitle)
+
+	resourceName := fmt.Sprintf("secretsmanager_pam_remote_browser.%v", secretTitle)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr(resourceName, "type", "pamRemoteBrowser"),
+					resource.TestCheckResourceAttr(resourceName, "title", secretTitle),
+					resource.TestCheckResourceAttr(resourceName, "notes", secretTitle),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePamRemoteBrowser_create_no_uid(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretTitle := "tf_acc_test_pam_rb_no_uid"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_remote_browser" "%v" {
+			folder_uid = "%v"
+			title = "%v"
+			rbi_url {
+				value = "https://admin.example.com"
+			}
+		}
+	`, secretTitle, secretFolderUid, secretTitle)
+
+	resourceName := fmt.Sprintf("secretsmanager_pam_remote_browser.%v", secretTitle)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "pamRemoteBrowser"),
+					resource.TestCheckResourceAttr(resourceName, "title", secretTitle),
+					resource.TestCheckResourceAttrSet(resourceName, "uid"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePamRemoteBrowser_import(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_rb_import"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_remote_browser" "%v" {
+			folder_uid = "%v"
+			uid = "%v"
+			title = "%v"
+			rbi_url {
+				value = "https://portal.example.com"
+			}
+		}
+	`, secretTitle, secretFolderUid, secretUid, secretTitle)
+
+	resourceName := fmt.Sprintf("secretsmanager_pam_remote_browser.%v", secretTitle)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:        true,
+				ImportStateVerify:  true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return secretUid, nil
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up fixes for KSM-871 ephemeral resources (PR #74):

- **Fix**: Remove `DiffSuppressFunc` and `ValidateFunc` from computed-only `pam_remote_browser_settings` field in the data source — Terraform rejects these on computed-only fields
- **Tests**: Add missing PAM ephemeral test files (pam_user, pam_machine, pam_database, pam_directory, pam_remote_browser)
- **Tests**: Add comprehensive error-case tests (wrong record type, invalid path)
- **Tests**: Add search-by-title tests for login, field, and record ephemeral resources
- **Tests**: Add pamRemoteBrowser resource CRUD tests (create, create_no_uid, import) and data source test
- **Example**: Add missing `pam_remote_browser.tf` example

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] All new test files compile
- [ ] E2E tested with `terraform plan` + `terraform apply` against real Keeper records