### PR TITLE
feat(KSM-388): add custom fields to all 22 resource types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pam_machine` and `pam_user` use merge-aware logic to preserve the vault-managed "Private Key Passphrase" custom field across create/update operations
   - `required` and `privacy_screen` attributes round-trip correctly from vault state (no perpetual diff on import)
 
+### Fixed
+- **Custom fields — `paymentCard` perpetual diff** (KSM-888): `jsonencode()` values must use camelCase keys — `cardNumber`, `cardExpirationDate`, `cardSecurityCode` — matching Keeper's API format. Snake_case keys (`card_number`, etc.) were previously silently ignored, causing the field to be written empty and producing a perpetual plan diff.
+- **Custom fields — non-canonical `checkbox` values** (KSM-889): only `"true"` or `"false"` are accepted. Other strings like `"yes"` or `"1"` now return a clear error instead of being silently coerced to `false`.
+- **Custom fields — non-canonical date values** (KSM-889): `date`, `birthDate`, and `expirationDate` only accept YYYY-MM-DD format. RFC3339 input (e.g. `"2026-03-20T14:30:00Z"`) now returns a clear error instead of causing a perpetual plan diff (config kept RFC3339; state returned YYYY-MM-DD).
+
 ## [1.3.0]
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Custom Fields** (KSM-388):
+  - Add `custom` block to all 22 resource types (`login`, `bank_account`, `bank_card`, `birth_certificate`, `contact`, `database_credentials`, `driver_license`, `encrypted_notes`, `file`, `health_insurance`, `membership`, `passport`, `photo`, `server_credentials`, `software_license`, `ssh_keys`, `ssn_card`, `address`, `pam_database`, `pam_directory`, `pam_machine`, `pam_remote_browser`, `pam_user`)
+  - Supports 43+ Keeper field types including `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`, and more
+  - Simple types use a plain string `value`; complex types use `value = jsonencode({...})` for a single entry or `value = jsonencode([{...},{...}])` for multiple entries in one field
+  - `pam_machine` and `pam_user` use merge-aware logic to preserve the vault-managed "Private Key Passphrase" custom field across create/update operations
+  - `required` and `privacy_screen` attributes round-trip correctly from vault state (no perpetual diff on import)
+
 ## [1.3.0]
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add nil-check guard in all ephemeral resource `Open()` methods to prevent panics if provider configuration is missing
 - Surface warning diagnostics when referenced `addressRef` or `cardRef` records cannot be fetched, instead of silently returning empty fields
 - Mark `credential` provider attribute as sensitive to prevent credentials appearing in plan output
+- Mark sensitive fields across all record types to prevent secrets appearing in plan output: payment card numbers and security codes, bank account and routing numbers, PIN codes, TOTP seeds, license numbers, and secret field values
 
 ## [1.2.0]
 

--- a/docs/resources/address.md
+++ b/docs/resources/address.md
@@ -110,4 +110,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/address.md
+++ b/docs/resources/address.md
@@ -37,6 +37,8 @@ resource "secretsmanager_address" "my_address" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -95,3 +97,17 @@ Read-Only:
 - **size** (Number) The file size.
 - **title** (String) The file title.
 - **type** (String) The file type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/bank_account.md
+++ b/docs/resources/bank_account.md
@@ -96,6 +96,8 @@ resource "secretsmanager_bank_account" "my_bank_account" {
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 - **url** (Block List, Max: 1) URL field data. (see [below for nested schema](#nestedblock--url))
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -259,3 +261,17 @@ Optional:
 Read-Only:
 
 - **type** (String) Field type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/bank_account.md
+++ b/docs/resources/bank_account.md
@@ -119,10 +119,10 @@ Read-Only:
 
 Optional:
 
-- **account_number** (String) Account number.
+- **account_number** (String, Sensitive) Account number.
 - **account_type** (String) Account type.
 - **other_type** (String) Other type info.
-- **routing_number** (String) Routing number.
+- **routing_number** (String, Sensitive) Routing number.
 
 <a id="nestedblock--card_ref"></a>
 ### Nested Schema for `card_ref`
@@ -240,7 +240,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/bank_account.md
+++ b/docs/resources/bank_account.md
@@ -274,4 +274,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/bank_card.md
+++ b/docs/resources/bank_card.md
@@ -59,6 +59,8 @@ resource "secretsmanager_bank_card" "my_bank_card" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -156,3 +158,17 @@ Optional:
 Read-Only:
 
 - **type** (String) Field type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/bank_card.md
+++ b/docs/resources/bank_card.md
@@ -140,8 +140,8 @@ Read-Only:
 Optional:
 
 - **card_expiration_date** (String) Card expiration date.
-- **card_number** (String) Card number.
-- **card_security_code** (String) Card security code.
+- **card_number** (String, Sensitive) Card number.
+- **card_security_code** (String, Sensitive) Card security code.
 
 <a id="nestedblock--pin_code"></a>
 ### Nested Schema for `pin_code`
@@ -151,7 +151,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/bank_card.md
+++ b/docs/resources/bank_card.md
@@ -171,4 +171,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/birth_certificate.md
+++ b/docs/resources/birth_certificate.md
@@ -128,4 +128,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/birth_certificate.md
+++ b/docs/resources/birth_certificate.md
@@ -44,6 +44,8 @@ resource "secretsmanager_birth_certificate" "my_birth_certificate" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -113,3 +115,17 @@ Optional:
 - **first** (String) First name.
 - **last** (String) Last name.
 - **middle** (String) MIddle name.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/contact.md
+++ b/docs/resources/contact.md
@@ -72,6 +72,8 @@ resource "secretsmanager_contact" "my_contact" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -193,3 +195,17 @@ Optional:
 - **number** (String) Phone number - ex. 510-222-5555
 - **region** (String) Region code - ex. US
 - **type** (String) Phone number type - ex. Home, Work, or Mobile
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/contact.md
+++ b/docs/resources/contact.md
@@ -208,4 +208,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/database_credentials.md
+++ b/docs/resources/database_credentials.md
@@ -66,6 +66,8 @@ resource "secretsmanager_database_credentials" "my_database_credentials" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -176,3 +178,17 @@ Optional:
 - **length** (Number) Password length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/database_credentials.md
+++ b/docs/resources/database_credentials.md
@@ -191,4 +191,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/driver_license.md
+++ b/docs/resources/driver_license.md
@@ -107,7 +107,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/driver_license.md
+++ b/docs/resources/driver_license.md
@@ -67,6 +67,8 @@ resource "secretsmanager_driver_license" "my_driver_license" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -178,3 +180,17 @@ Optional:
 - **first** (String) First name.
 - **last** (String) Last name.
 - **middle** (String) MIddle name.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/driver_license.md
+++ b/docs/resources/driver_license.md
@@ -193,4 +193,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/encrypted_notes.md
+++ b/docs/resources/encrypted_notes.md
@@ -114,4 +114,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/encrypted_notes.md
+++ b/docs/resources/encrypted_notes.md
@@ -39,6 +39,8 @@ resource "secretsmanager_encrypted_notes" "my_encrypted_notes" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -99,3 +101,17 @@ Optional:
 Read-Only:
 
 - **type** (String) Field type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -75,4 +75,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -28,6 +28,8 @@ resource "secretsmanager_file" "my_files" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -60,3 +62,17 @@ Read-Only:
 - **size** (Number) The file size.
 - **title** (String) The file title.
 - **type** (String) The file type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -14,6 +14,22 @@ Use this resource to manage folders in Keeper Vault
 - **force_delete** (Boolean) Force deletion of non empty folders.
 - **id** (String) The ID of this resource.
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **uid** (String) The folder UID (using RFC4648 URL and Filename Safe Alphabet).
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -32,4 +32,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/health_insurance.md
+++ b/docs/resources/health_insurance.md
@@ -215,4 +215,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/health_insurance.md
+++ b/docs/resources/health_insurance.md
@@ -87,7 +87,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/health_insurance.md
+++ b/docs/resources/health_insurance.md
@@ -75,6 +75,8 @@ resource "secretsmanager_health_insurance" "my_health_insurance" {
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 - **url** (Block List, Max: 1) URL field data. (see [below for nested schema](#nestedblock--url))
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -200,3 +202,17 @@ Optional:
 Read-Only:
 
 - **type** (String) Field type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -180,4 +180,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -63,6 +63,8 @@ resource "secretsmanager_login" "my_login" {
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 - **url** (Block List, Max: 1) URL field data. (see [below for nested schema](#nestedblock--url))
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -165,3 +167,17 @@ Optional:
 Read-Only:
 
 - **type** (String) Field type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -146,7 +146,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/membership.md
+++ b/docs/resources/membership.md
@@ -71,7 +71,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/membership.md
+++ b/docs/resources/membership.md
@@ -59,6 +59,8 @@ resource "secretsmanager_membership" "my_membership" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -156,3 +158,17 @@ Optional:
 - **length** (Number) Password length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/membership.md
+++ b/docs/resources/membership.md
@@ -171,4 +171,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/pam_database.md
+++ b/docs/resources/pam_database.md
@@ -1,0 +1,106 @@
+# secretsmanager_pam_database Resource
+
+Use this resource to create and manage PAM Database records in Keeper Vault. Supports PostgreSQL, MySQL, MongoDB, and other database types for privileged access management.
+
+## Example Usage
+
+### PostgreSQL Database
+
+```terraform
+resource "secretsmanager_pam_database" "postgres" {
+  folder_uid = "<folder UID>"
+  title      = "Production PostgreSQL"
+
+  pam_hostname {
+    value {
+      hostname = "postgres.prod.example.com"
+      port     = "5432"
+    }
+  }
+
+  database_type = "postgresql"
+
+  pam_settings = jsonencode([{
+    connection = [{
+      protocol = "postgresql"
+      port     = "5432"
+    }]
+  }])
+}
+```
+
+### Database with Custom Fields
+
+```terraform
+resource "secretsmanager_pam_database" "mysql_staging" {
+  folder_uid = "<folder UID>"
+  title      = "Staging MySQL"
+
+  pam_hostname {
+    value {
+      hostname = "mysql.staging.example.com"
+      port     = "3306"
+    }
+  }
+
+  database_type = "mysql"
+
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "staging"
+  }
+
+  custom {
+    type  = "text"
+    label = "Team"
+    value = "platform"
+  }
+}
+```
+
+## Argument Reference
+
+* `folder_uid` - (Optional) The UID of the shared folder where the record will be created. At least one of `folder_uid` or `uid` must be set.
+* `uid` - (Optional) The UID for the new record (RFC 4648 URL-safe base64). Auto-generated if not set. At least one of `folder_uid` or `uid` must be set.
+* `title` - (Optional) The record title.
+* `notes` - (Optional) The record notes.
+* `pam_hostname` - (Optional) Database hostname and port.
+* `database_type` - (Optional) Database type string (e.g. `postgresql`, `mysql`, `mongodb`).
+* `database_id` - (Optional) Database identifier (e.g. RDS instance ID). Block with `value` attribute.
+* `use_ssl` - (Optional) SSL enabled flag. Block with `value` (boolean) attribute.
+* `pam_settings` - (Optional) Connection and port-forward settings as a JSON string. Use `jsonencode()`.
+* `rotation_scripts` - (Optional) Rotation script references.
+* `provider_group` - (Optional) Cloud provider group. Block with `value` attribute.
+* `provider_region` - (Optional) Cloud provider region. Block with `value` attribute.
+* `file_ref` - (Optional) File references.
+* `totp` - (Optional) One-time code (otpauth:// URI).
+* `custom` - (Optional) User-defined custom fields. Each block requires `type` (Keeper field type) and `label` (display name), with optional `value` (plain string or `jsonencode()` for complex types), `required`, and `privacy_screen`. See [Nested Schema for `custom`](#nestedblock--custom) below.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `type` - The record type (`pamDatabase`).
+
+## Import
+
+PAM Database records can be imported using their UID:
+
+```
+$ terraform import secretsmanager_pam_database.example <record_UID>
+```
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/pam_database.md
+++ b/docs/resources/pam_database.md
@@ -103,4 +103,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/pam_directory.md
+++ b/docs/resources/pam_directory.md
@@ -103,4 +103,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/pam_directory.md
+++ b/docs/resources/pam_directory.md
@@ -1,0 +1,106 @@
+# secretsmanager_pam_directory Resource
+
+Use this resource to create and manage PAM Directory records in Keeper Vault. Supports Active Directory, OpenLDAP, and other LDAP-compatible directories for privileged access management.
+
+## Example Usage
+
+### Active Directory
+
+```terraform
+resource "secretsmanager_pam_directory" "ad" {
+  folder_uid = "<folder UID>"
+  title      = "Corporate Active Directory"
+
+  pam_hostname {
+    value {
+      hostname = "dc.corp.example.com"
+      port     = "636"
+    }
+  }
+
+  directory_type = "Active Directory"
+
+  distinguished_name {
+    label = "Base DN"
+    value = "DC=corp,DC=example,DC=com"
+  }
+
+  use_ssl {
+    value = true
+  }
+}
+```
+
+### Directory with Custom Fields
+
+```terraform
+resource "secretsmanager_pam_directory" "openldap" {
+  folder_uid = "<folder UID>"
+  title      = "OpenLDAP Staging"
+
+  pam_hostname {
+    value {
+      hostname = "ldap.staging.example.com"
+      port     = "389"
+    }
+  }
+
+  directory_type = "OpenLDAP"
+
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "staging"
+  }
+}
+```
+
+## Argument Reference
+
+* `folder_uid` - (Optional) The UID of the shared folder where the record will be created. At least one of `folder_uid` or `uid` must be set.
+* `uid` - (Optional) The UID for the new record (RFC 4648 URL-safe base64). Auto-generated if not set. At least one of `folder_uid` or `uid` must be set.
+* `title` - (Optional) The record title.
+* `notes` - (Optional) The record notes.
+* `pam_hostname` - (Optional) Directory server hostname and port.
+* `directory_type` - (Optional) Directory type string (e.g. `Active Directory`, `OpenLDAP`).
+* `distinguished_name` - (Optional) Base DN or search base. Block with `label` and `value` attributes.
+* `domain_name` - (Optional) Domain name. Block with `value` attribute.
+* `directory_id` - (Optional) Directory identifier. Block with `value` attribute.
+* `user_match` - (Optional) User match filter. Block with `value` attribute.
+* `use_ssl` - (Optional) SSL/TLS enabled flag. Block with `value` (boolean) attribute.
+* `alternative_ips` - (Optional) Alternative IP addresses. Block with `value` attribute.
+* `pam_settings` - (Optional) Connection and port-forward settings as a JSON string. Use `jsonencode()`.
+* `rotation_scripts` - (Optional) Rotation script references.
+* `provider_group` - (Optional) Cloud provider group. Block with `value` attribute.
+* `provider_region` - (Optional) Cloud provider region. Block with `value` attribute.
+* `file_ref` - (Optional) File references.
+* `totp` - (Optional) One-time code (otpauth:// URI).
+* `custom` - (Optional) User-defined custom fields. Each block requires `type` (Keeper field type) and `label` (display name), with optional `value` (plain string or `jsonencode()` for complex types), `required`, and `privacy_screen`. See [Nested Schema for `custom`](#nestedblock--custom) below.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `type` - The record type (`pamDirectory`).
+
+## Import
+
+PAM Directory records can be imported using their UID:
+
+```
+$ terraform import secretsmanager_pam_directory.example <record_UID>
+```
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/pam_machine.md
+++ b/docs/resources/pam_machine.md
@@ -92,6 +92,8 @@ resource "secretsmanager_pam_machine" "ssh_machine" {
 - **totp** (Block List, Max: 1) One-time code field data.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -139,3 +141,17 @@ Optional:
 - **length** (Number) Passphrase length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/pam_machine.md
+++ b/docs/resources/pam_machine.md
@@ -154,4 +154,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/pam_remote_browser.md
+++ b/docs/resources/pam_remote_browser.md
@@ -76,4 +76,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/pam_remote_browser.md
+++ b/docs/resources/pam_remote_browser.md
@@ -48,6 +48,7 @@ resource "secretsmanager_pam_remote_browser" "with_settings" {
 * `traffic_encryption_seed` - (Optional) Base64-encoded 256-bit encryption seed. Block with `value` attribute.
 * `file_ref` - (Optional) File references.
 * `totp` - (Optional) One-time code (otpauth:// URI).
+* `custom` - (Optional) User-defined custom fields. Each block requires `type` (Keeper field type) and `label` (display name), with optional `value` (plain string or `jsonencode()` for complex types), `required`, and `privacy_screen`. See [Nested Schema for `custom`](#nestedblock--custom) below.
 
 ## Attributes Reference
 
@@ -62,3 +63,17 @@ PAM Remote Browser records can be imported using their UID:
 ```
 $ terraform import secretsmanager_pam_remote_browser.example <record_UID>
 ```
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/pam_user.md
+++ b/docs/resources/pam_user.md
@@ -94,6 +94,8 @@ resource "secretsmanager_pam_user" "rsa_user" {
 - **totp** (Block List, Max: 1) One-time code field data.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -141,3 +143,17 @@ Optional:
 - **length** (Number) Passphrase length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/pam_user.md
+++ b/docs/resources/pam_user.md
@@ -156,4 +156,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/passport.md
+++ b/docs/resources/passport.md
@@ -91,6 +91,8 @@ resource "secretsmanager_passport" "my_passport" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -244,3 +246,17 @@ Optional:
 - **length** (Number) Password length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/passport.md
+++ b/docs/resources/passport.md
@@ -259,4 +259,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/photo.md
+++ b/docs/resources/photo.md
@@ -28,6 +28,8 @@ resource "secretsmanager_photo" "my_photos" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -60,3 +62,17 @@ Read-Only:
 - **size** (Number) The file size.
 - **title** (String) The file title.
 - **type** (String) The file type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/photo.md
+++ b/docs/resources/photo.md
@@ -75,4 +75,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/server_credentials.md
+++ b/docs/resources/server_credentials.md
@@ -169,4 +169,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/server_credentials.md
+++ b/docs/resources/server_credentials.md
@@ -58,6 +58,8 @@ resource "secretsmanager_server_credentials" "my_server_credentials" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -154,3 +156,17 @@ Optional:
 - **length** (Number) Password length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/software_license.md
+++ b/docs/resources/software_license.md
@@ -47,6 +47,8 @@ resource "secretsmanager_software_license" "my_software_license" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -121,3 +123,17 @@ Optional:
 Read-Only:
 
 - **type** (String) Field type.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/software_license.md
+++ b/docs/resources/software_license.md
@@ -116,7 +116,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/docs/resources/software_license.md
+++ b/docs/resources/software_license.md
@@ -136,4 +136,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/ssh_keys.md
+++ b/docs/resources/ssh_keys.md
@@ -101,6 +101,8 @@ resource "secretsmanager_ssh_keys" "generated_with_passphrase" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -224,3 +226,17 @@ Optional:
 - **length** (Number) Password length.
 - **lowercase** (Number) Number of lowercase characters.
 - **special** (Number) Number of special characters.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/ssh_keys.md
+++ b/docs/resources/ssh_keys.md
@@ -239,4 +239,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/ssn_card.md
+++ b/docs/resources/ssn_card.md
@@ -127,4 +127,4 @@ Optional:
 
 - **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
 - **required** (Boolean) Whether this field is required.
-- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field. Format constraints: `checkbox` requires `"true"` or `"false"`; `date`, `birthDate`, and `expirationDate` require YYYY-MM-DD; `paymentCard` `jsonencode` keys use camelCase (`cardNumber`, `cardExpirationDate`, `cardSecurityCode`).

--- a/docs/resources/ssn_card.md
+++ b/docs/resources/ssn_card.md
@@ -43,6 +43,8 @@ resource "secretsmanager_ssn_card" "my_ssn_card" {
 - **title** (String) The secret title.
 - **uid** (String) The UID of the new secret (using RFC4648 URL and Filename Safe Alphabet).
 
+- **custom** (Block List) User-defined custom fields. (see [below for nested schema](#nestedblock--custom))
+
 ### Read-Only
 
 - **type** (String) The secret type.
@@ -112,3 +114,17 @@ Optional:
 - **first** (String) First name.
 - **last** (String) Last name.
 - **middle** (String) MIddle name.
+
+<a id="nestedblock--custom"></a>
+### Nested Schema for `custom`
+
+Required:
+
+- **label** (String) Display name for the field in Keeper UI.
+- **type** (String) Keeper field type. Common values: `text`, `secret`, `url`, `email`, `phone`, `date`, `birthDate`, `expirationDate`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `keyPair`, `securityQuestion`, `checkbox`, `multiline`.
+
+Optional:
+
+- **privacy_screen** (Boolean) Whether this field is hidden behind a privacy screen in the Keeper UI.
+- **required** (Boolean) Whether this field is required.
+- **value** (String, Sensitive) Field value. Plain string for simple types. Use `jsonencode({...})` for structured types or `jsonencode([{...},{...}])` for multiple entries in one field.

--- a/docs/resources/ssn_card.md
+++ b/docs/resources/ssn_card.md
@@ -84,7 +84,7 @@ Optional:
 - **label** (String) Field label.
 - **privacy_screen** (Boolean) Privacy screen flag.
 - **required** (Boolean) Required flag.
-- **value** (String) Field value.
+- **value** (String, Sensitive) Field value.
 
 Read-Only:
 

--- a/examples/resources/address.tf
+++ b/examples/resources/address.tf
@@ -34,6 +34,14 @@ resource "secretsmanager_address" "my_address" {
       zip     = "90003-2334"
     }
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/bank_account.tf
+++ b/examples/resources/bank_account.tf
@@ -81,6 +81,14 @@ resource "secretsmanager_bank_account" "my_bank_account" {
     privacy_screen = true
     value          = "otpauth://totp/Acme:Buster?secret=6I4PI5EUKS66GPRY5TMLJJP25MAYWAVL&issuer=Acme&algorithm=SHA1&digits=6&period=30"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/bank_card.tf
+++ b/examples/resources/bank_card.tf
@@ -49,6 +49,14 @@ resource "secretsmanager_bank_card" "my_bank_card" {
     privacy_screen = true
     value          = "<address ref UID>"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/birth_certificate.tf
+++ b/examples/resources/birth_certificate.tf
@@ -39,6 +39,14 @@ resource "secretsmanager_birth_certificate" "my_birth_certificate" {
     # unix time in milliseconds
     # unix time seconds can be produced using time_static resource from hashicorp/time provider
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/contact.tf
+++ b/examples/resources/contact.tf
@@ -60,6 +60,14 @@ resource "secretsmanager_contact" "my_contact" {
     privacy_screen = true
     value          = "<address ref UID>"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/database_credentials.tf
+++ b/examples/resources/database_credentials.tf
@@ -57,6 +57,14 @@ resource "secretsmanager_database_credentials" "my_database_credentials" {
     privacy_screen = true
     value          = "MySQL"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/driver_license.tf
+++ b/examples/resources/driver_license.tf
@@ -57,6 +57,14 @@ resource "secretsmanager_driver_license" "my_driver_license" {
     privacy_screen = true
     value          = "<address ref UID>"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/encrypted_notes.tf
+++ b/examples/resources/encrypted_notes.tf
@@ -34,6 +34,14 @@ resource "secretsmanager_encrypted_notes" "my_encrypted_notes" {
     value          = 1651186276
     # unix time in milliseconds
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/file.tf
+++ b/examples/resources/file.tf
@@ -25,6 +25,14 @@ resource "secretsmanager_file" "my_files" {
     value { uid = "<file1 UID>" }
     value { uid = "<file2 UID>" }
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/folder.tf
+++ b/examples/resources/folder.tf
@@ -20,6 +20,14 @@ provider "secretsmanager" {
 resource "secretsmanager_folder" "my_folder" {
   parent_uid = "<Parent Folder UID>"
   name       = "<Folder Name>"
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/health_insurance.tf
+++ b/examples/resources/health_insurance.tf
@@ -64,6 +64,14 @@ resource "secretsmanager_health_insurance" "my_health_insurance" {
     privacy_screen = true
     value          = "https://192.168.1.1/"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/login.tf
+++ b/examples/resources/login.tf
@@ -76,11 +76,29 @@ resource "secretsmanager_login" "my_login" {
     value = jsonencode({ region = "US", number = "555-867-5309", type = "Work" })
   }
 
-  # Date custom field — YYYY-MM-DD format
+  # Date custom field — YYYY-MM-DD only (RFC3339 is not accepted)
   custom {
     type  = "date"
     label = "CertExpiry"
     value = "2027-06-01"
+  }
+
+  # Checkbox custom field — must be "true" or "false" (not "yes", "1", etc.)
+  custom {
+    type  = "checkbox"
+    label = "MFAEnabled"
+    value = "true"
+  }
+
+  # Payment card custom field — jsonencode keys must be camelCase
+  custom {
+    type  = "paymentCard"
+    label = "Corporate Card"
+    value = jsonencode({
+      cardNumber         = "4111111111111111"
+      cardExpirationDate = "12/2027"
+      cardSecurityCode   = "123"
+    })
   }
 }
 

--- a/examples/resources/login.tf
+++ b/examples/resources/login.tf
@@ -54,6 +54,34 @@ resource "secretsmanager_login" "my_login" {
     privacy_screen = true
     value          = "otpauth://totp/Acme:Buster?secret=6I4PI5EUKS66GPRY5TMLJJP25MAYWAVL&issuer=Acme&algorithm=SHA1&digits=6&period=30"
   }
+
+  # Simple custom field — plain string value
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
+  # Secret custom field — treated as sensitive
+  custom {
+    type  = "secret"
+    label = "ApiKey"
+    value = "sk-prod-..."
+  }
+
+  # Complex custom field — use jsonencode() for structured types
+  custom {
+    type  = "phone"
+    label = "SupportLine"
+    value = jsonencode({ region = "US", number = "555-867-5309", type = "Work" })
+  }
+
+  # Date custom field — YYYY-MM-DD format
+  custom {
+    type  = "date"
+    label = "CertExpiry"
+    value = "2027-06-01"
+  }
 }
 
 resource "local_file" "out" {

--- a/examples/resources/membership.tf
+++ b/examples/resources/membership.tf
@@ -52,6 +52,14 @@ resource "secretsmanager_membership" "my_membership" {
     }
     #value = "to_be_generated"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/pam_database.tf
+++ b/examples/resources/pam_database.tf
@@ -54,6 +54,14 @@ resource "secretsmanager_pam_database" "postgres_prod" {
     label = "Default Database"
     value = "production"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 # Example 2: MySQL Database

--- a/examples/resources/pam_directory.tf
+++ b/examples/resources/pam_directory.tf
@@ -50,6 +50,14 @@ resource "secretsmanager_pam_directory" "active_directory" {
     label = "Use SSL"
     value = true
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 # Example 2: OpenLDAP PAM Directory

--- a/examples/resources/pam_machine.tf
+++ b/examples/resources/pam_machine.tf
@@ -46,6 +46,14 @@ resource "secretsmanager_pam_machine" "ssh_server" {
       reusePort = true
     }]
   }])
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 # Example 2: PAM Machine with RDP protocol

--- a/examples/resources/pam_user.tf
+++ b/examples/resources/pam_user.tf
@@ -58,6 +58,14 @@ resource "secretsmanager_pam_user" "db_admin" {
     label = "Managed"
     value = true
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 # Example 2: PAM User with rotation scripts

--- a/examples/resources/passport.tf
+++ b/examples/resources/passport.tf
@@ -79,6 +79,14 @@ resource "secretsmanager_passport" "my_passport" {
     privacy_screen = true
     value          = "<address ref UID>"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/photo.tf
+++ b/examples/resources/photo.tf
@@ -25,6 +25,14 @@ resource "secretsmanager_photo" "my_photos" {
     value { uid = "<file1 UID>" }
     value { uid = "<file2 UID>" }
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/server_credentials.tf
+++ b/examples/resources/server_credentials.tf
@@ -51,6 +51,14 @@ resource "secretsmanager_server_credentials" "my_server_credentials" {
     }
     #value = "to_be_generated"
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/software_license.tf
+++ b/examples/resources/software_license.tf
@@ -41,6 +41,14 @@ resource "secretsmanager_software_license" "my_software_license" {
     value          = 21651186276
     # unix time in milliseconds
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/ssh_keys.tf
+++ b/examples/resources/ssh_keys.tf
@@ -60,6 +60,14 @@ resource "secretsmanager_ssh_keys" "my_ssh_keys" {
       private_key = "<PRIVATE KEY>"
     }
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/examples/resources/ssn_card.tf
+++ b/examples/resources/ssn_card.tf
@@ -37,6 +37,14 @@ resource "secretsmanager_ssn_card" "my_ssn_card" {
       last   = "Doe"
     }
   }
+
+  # Custom fields — attach arbitrary typed data to the record
+  custom {
+    type  = "text"
+    label = "Environment"
+    value = "production"
+  }
+
 }
 
 resource "local_file" "out" {

--- a/secretsmanager/custom_fields_schema_test.go
+++ b/secretsmanager/custom_fields_schema_test.go
@@ -1,0 +1,66 @@
+package secretsmanager
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestCustomFieldSchemaPresence verifies that every record resource schema
+// contains the "custom" TypeList key with the expected 5 sub-attributes.
+//
+// This is a structural check — it does not require a live vault. It catches:
+//   - Resources where schemaCustomField() was accidentally omitted
+//   - Sub-attribute regressions (missing or renamed keys)
+//
+// Runtime wiring (HasChange/d.Get) is verified by per-resource acceptance tests
+// and the grep in CI.
+func TestCustomFieldSchemaPresence(t *testing.T) {
+	resources := map[string]*schema.Resource{
+		"address":              resourceAddress(),
+		"bank_account":         resourceBankAccount(),
+		"bank_card":            resourceBankCard(),
+		"birth_certificate":    resourceBirthCertificate(),
+		"contact":              resourceContact(),
+		"database_credentials": resourceDatabaseCredentials(),
+		"driver_license":       resourceDriverLicense(),
+		"encrypted_notes":      resourceEncryptedNotes(),
+		"health_insurance":     resourceHealthInsurance(),
+		"login":                resourceLogin(),
+		"membership":           resourceMembership(),
+		"pam_database":         resourcePamDatabase(),
+		"pam_directory":        resourcePamDirectory(),
+		"pam_machine":          resourcePamMachine(),
+		"pam_remote_browser":   resourcePamRemoteBrowser(),
+		"pam_user":             resourcePamUser(),
+		"passport":             resourcePassport(),
+		"photo":                resourcePhoto(),
+		"server_credentials":   resourceServerCredentials(),
+		"software_license":     resourceSoftwareLicense(),
+		"ssh_keys":             resourceSshKeys(),
+		"ssn_card":             resourceSsnCard(),
+	}
+
+	requiredSubKeys := []string{"type", "label", "value", "required", "privacy_screen"}
+
+	for name, res := range resources {
+		t.Run(name, func(t *testing.T) {
+			customSchema, ok := res.Schema["custom"]
+			if !ok {
+				t.Fatalf("resource %q: \"custom\" key missing from schema", name)
+			}
+			if customSchema.Type != schema.TypeList {
+				t.Errorf("resource %q: \"custom\" is %v, want TypeList", name, customSchema.Type)
+			}
+			elem, ok := customSchema.Elem.(*schema.Resource)
+			if !ok {
+				t.Fatalf("resource %q: \"custom\" Elem is not *schema.Resource", name)
+			}
+			for _, key := range requiredSubKeys {
+				if _, found := elem.Schema[key]; !found {
+					t.Errorf("resource %q: \"custom\" block missing sub-key %q", name, key)
+				}
+			}
+		})
+	}
+}

--- a/secretsmanager/custom_fields_unit_test.go
+++ b/secretsmanager/custom_fields_unit_test.go
@@ -1,0 +1,123 @@
+package secretsmanager
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEpochMsToDateUTC verifies that date conversion always uses UTC.
+//
+// The bug this guards against: using local time instead of UTC shifts
+// midnight-UTC dates back by one day on machines in negative-offset timezones
+// (e.g. UTC-8 US/Pacific), causing a perpetual Terraform diff on every plan.
+//
+// These test cases use midnight UTC so the expected value is unambiguous —
+// any local timezone behind UTC would return the previous day without the fix.
+func TestEpochMsToDateUTC(t *testing.T) {
+	tests := []struct {
+		name  string
+		ms    float64
+		want  string
+	}{
+		{
+			// 2025-01-01T00:00:00Z — midnight UTC, New Year's Day.
+			// UTC-1 through UTC-12 would return "2024-12-31" without .UTC().
+			name: "midnight_utc_jan_1",
+			ms:   1735689600000,
+			want: "2025-01-01",
+		},
+		{
+			// 2024-03-01T00:00:00Z — midnight UTC on first day of March in a leap year.
+			// UTC-1 through UTC-12 would return "2024-02-29" without .UTC().
+			name: "midnight_utc_march_1_leap_year",
+			ms:   1709251200000,
+			want: "2024-03-01",
+		},
+		{
+			// 2025-07-15T00:00:00Z — mid-year date, positive sanity check.
+			name: "midnight_utc_july_15",
+			ms:   1752537600000,
+			want: "2025-07-15",
+		},
+		{
+			// 2023-12-31T23:59:59.999Z — just before midnight UTC, should stay in 2023.
+			name: "just_before_midnight_utc",
+			ms:   1704067199999,
+			want: "2023-12-31",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := epochMsToDateUTC(tt.ms)
+			if got != tt.want {
+				t.Errorf("epochMsToDateUTC(%v) = %q, want %q", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseJSONItems verifies that parseJSONItems correctly distinguishes a single
+// JSON object from a JSON array, returning one item in both cases but with the
+// right structure so callers can unmarshal each entry uniformly.
+func TestParseJSONItems(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name:      "single_object",
+			input:     `{"region":"US","number":"555-1234","type":"Work"}`,
+			wantCount: 1,
+		},
+		{
+			name:      "array_one_entry",
+			input:     `[{"region":"US","number":"555-1234","type":"Work"}]`,
+			wantCount: 1,
+		},
+		{
+			name:      "array_two_entries",
+			input:     `[{"region":"US","number":"555-1234","type":"Work"},{"region":"US","number":"555-5678","type":"Mobile"}]`,
+			wantCount: 2,
+		},
+		{
+			name:      "empty_array",
+			input:     `[]`,
+			wantCount: 0,
+		},
+		{
+			// Invalid JSON that starts with '[' is caught immediately by json.Unmarshal.
+			// Invalid JSON that does NOT start with '[' is passed through as a raw message
+			// and caught later by the caller's per-entry Unmarshal — not parseJSONItems itself.
+			name:    "invalid_array_json",
+			input:   `[not valid json]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items, err := parseJSONItems(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseJSONItems(%q): expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseJSONItems(%q): unexpected error: %v", tt.input, err)
+			}
+			if len(items) != tt.wantCount {
+				t.Errorf("parseJSONItems(%q): got %d items, want %d", tt.input, len(items), tt.wantCount)
+			}
+			// Verify each item is valid JSON
+			for i, item := range items {
+				if !json.Valid(item) {
+					t.Errorf("item[%d] is not valid JSON: %s", i, item)
+				}
+			}
+		})
+	}
+}

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -337,6 +337,142 @@ func getFieldItemsData(recordDict map[string]interface{}, section string) []inte
 	return fis
 }
 
+// customFieldsFromSchema converts the "custom" TypeList from schema into a slice of
+// Keeper SDK field objects suitable for RecordCreate.Custom or RecordUpdate.
+// Each item has type, label, value (string), required, privacy_screen.
+// For complex types (phone, name, address, paymentCard), value must be a JSON string
+// (use jsonencode() in HCL). For date, value must be RFC3339.
+func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
+	fields := []interface{}{}
+	for _, item := range items {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		fieldType, _ := m["type"].(string)
+		label, _ := m["label"].(string)
+		value, _ := m["value"].(string)
+		required, _ := m["required"].(bool)
+		privacyScreen, _ := m["privacy_screen"].(bool)
+
+		base := core.KeeperRecordField{Type: fieldType, Label: label}
+
+		switch fieldType {
+		case "text", "multiline", "secret", "url", "email", "login", "password", "pinCode",
+			"accountNumber", "licenseNumber", "checkbox":
+			f := &core.Text{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			f.Type = fieldType
+			if value != "" {
+				f.Value = []string{value}
+			}
+			fields = append(fields, f)
+
+		case "date":
+			f := &core.Date{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				t, err := time.Parse(time.RFC3339, value)
+				if err != nil {
+					// fall back to date-only format
+					t, err = time.Parse("2006-01-02", value)
+					if err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid date value %q — use RFC3339 or YYYY-MM-DD", label, value)
+					}
+				}
+				f.Value = []int64{t.UnixMilli()}
+			}
+			fields = append(fields, f)
+
+		case "phone":
+			f := &core.Phones{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				var v map[string]interface{}
+				if err := json.Unmarshal([]byte(value), &v); err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for phone value: %w", label, err)
+				}
+				phone := core.Phone{}
+				if s, ok := v["region"].(string); ok { phone.Region = s }
+				if s, ok := v["number"].(string); ok { phone.Number = s }
+				if s, ok := v["ext"].(string); ok { phone.Ext = s }
+				if s, ok := v["type"].(string); ok { phone.Type = s }
+				f.Value = []core.Phone{phone}
+			}
+			fields = append(fields, f)
+
+		case "name":
+			f := &core.Names{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				var v map[string]interface{}
+				if err := json.Unmarshal([]byte(value), &v); err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for name value: %w", label, err)
+				}
+				name := core.Name{}
+				if s, ok := v["first"].(string); ok { name.First = s }
+				if s, ok := v["middle"].(string); ok { name.Middle = s }
+				if s, ok := v["last"].(string); ok { name.Last = s }
+				f.Value = []core.Name{name}
+			}
+			fields = append(fields, f)
+
+		case "address":
+			f := &core.Addresses{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				var v map[string]interface{}
+				if err := json.Unmarshal([]byte(value), &v); err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for address value: %w", label, err)
+				}
+				addr := core.Address{}
+				if s, ok := v["street1"].(string); ok { addr.Street1 = s }
+				if s, ok := v["street2"].(string); ok { addr.Street2 = s }
+				if s, ok := v["city"].(string); ok { addr.City = s }
+				if s, ok := v["state"].(string); ok { addr.State = s }
+				if s, ok := v["country"].(string); ok { addr.Country = s }
+				if s, ok := v["zip"].(string); ok { addr.Zip = s }
+				f.Value = []core.Address{addr}
+			}
+			fields = append(fields, f)
+
+		case "paymentCard":
+			f := &core.PaymentCards{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				var v map[string]interface{}
+				if err := json.Unmarshal([]byte(value), &v); err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for paymentCard value: %w", label, err)
+				}
+				card := core.PaymentCard{}
+				if s, ok := v["card_number"].(string); ok { card.CardNumber = s }
+				if s, ok := v["card_expiration_date"].(string); ok { card.CardExpirationDate = s }
+				if s, ok := v["card_security_code"].(string); ok { card.CardSecurityCode = s }
+				f.Value = []core.PaymentCard{card}
+			}
+			fields = append(fields, f)
+
+		default:
+			// Unknown type: store as text so we don't silently drop it
+			f := &core.Text{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				f.Value = []string{value}
+			}
+			fields = append(fields, f)
+		}
+	}
+	return fields, nil
+}
+
+// customFieldsToDict converts SDK field objects back to the map slice that
+// RecordDict["custom"] expects, for use during updates.
+func customFieldsToDict(fields []interface{}) []interface{} {
+	result := []interface{}{}
+	for _, f := range fields {
+		if jsonBytes, err := json.Marshal(f); err == nil {
+			var m map[string]interface{}
+			if err := json.Unmarshal(jsonBytes, &m); err == nil {
+				result = append(result, m)
+			}
+		}
+	}
+	return result
+}
+
 func getTotpCode(totpUrl string) (code string, seconds int, err error) {
 	if totp, err := core.GetTotpCode(totpUrl); err == nil {
 		return totp.Code, totp.TimeLeft, nil

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -378,11 +378,18 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 
 		switch fieldType {
 		case "text", "multiline", "secret", "url", "email", "login", "password", "pinCode",
-			"accountNumber", "licenseNumber", "checkbox":
+			"accountNumber", "licenseNumber":
 			f := &core.Text{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			f.Type = fieldType
 			if value != "" {
 				f.Value = []string{value}
+			}
+			fields = append(fields, f)
+
+		case "checkbox":
+			f := &core.Checkbox{KeeperRecordField: base, Required: required}
+			if value != "" {
+				f.Value = []bool{strings.ToLower(value) == "true"}
 			}
 			fields = append(fields, f)
 

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -496,9 +496,9 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for paymentCard entry: %w", label, err)
 					}
 					card := core.PaymentCard{}
-					if s, ok := v["card_number"].(string); ok { card.CardNumber = s }
-					if s, ok := v["card_expiration_date"].(string); ok { card.CardExpirationDate = s }
-					if s, ok := v["card_security_code"].(string); ok { card.CardSecurityCode = s }
+					if s, ok := v["cardNumber"].(string); ok { card.CardNumber = s }
+					if s, ok := v["cardExpirationDate"].(string); ok { card.CardExpirationDate = s }
+					if s, ok := v["cardSecurityCode"].(string); ok { card.CardSecurityCode = s }
 					f.Value = append(f.Value, card)
 				}
 			}

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -397,22 +397,22 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 		case "checkbox":
 			f := &core.Checkbox{KeeperRecordField: base, Required: required}
 			if value != "" {
-				f.Value = []bool{strings.ToLower(value) == "true"}
+				lower := strings.ToLower(value)
+				if lower != "true" && lower != "false" {
+					return nil, fmt.Errorf("custom field %q: invalid checkbox value %q — use \"true\" or \"false\"", label, value)
+				}
+				f.Value = []bool{lower == "true"}
 			}
 			fields = append(fields, f)
 
 		case "date", "birthDate", "expirationDate":
 			f := &core.Date{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
-				t, err := time.Parse(time.RFC3339, value)
+				t, err := time.Parse("2006-01-02", value)
 				if err != nil {
-					// fall back to date-only format
-					t, err = time.Parse("2006-01-02", value)
-					if err != nil {
-						return nil, fmt.Errorf("custom field %q: invalid date value %q — use RFC3339 or YYYY-MM-DD", label, value)
-					}
+					return nil, fmt.Errorf("custom field %q: invalid date value %q — use YYYY-MM-DD format (e.g. \"2026-03-20\")", label, value)
 				}
-				f.Value = []int64{t.UnixMilli()}
+				f.Value = []int64{t.UTC().UnixMilli()}
 			}
 			fields = append(fields, f)
 

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -240,6 +240,14 @@ func toJsonDefault(v interface{}, defaultValue string) string {
 	return string(content)
 }
 
+// epochMsToDateUTC converts Keeper's epoch-millisecond date values to a YYYY-MM-DD
+// string in UTC. Using UTC is critical: without it, machines in negative-offset
+// timezones (e.g. US/Pacific, UTC-8) shift midnight-UTC dates back by one day,
+// causing a perpetual Terraform diff on every plan.
+func epochMsToDateUTC(ms float64) string {
+	return time.Unix(int64(ms/1000), 0).UTC().Format("2006-01-02")
+}
+
 func getFieldItemsData(recordDict map[string]interface{}, section string) []interface{} {
 	sections := []string{"fields", "custom"}
 	if len(recordDict) == 0 || !slices.Contains(sections, section) {
@@ -299,7 +307,7 @@ func getFieldItemsData(recordDict map[string]interface{}, section string) []inte
 				dates := []interface{}{}
 				for _, date := range sVals {
 					if d, success := date.(float64); success {
-						value := time.Unix(int64(d/1000), 0).UTC().Format("2006-01-02") // date only, UTC
+						value := epochMsToDateUTC(d)
 						dates = append(dates, value)
 					}
 				}
@@ -602,6 +610,35 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 					}
 					f.Value = append(f.Value, s)
 				}
+			}
+			fields = append(fields, f)
+
+		case "addressRef":
+			f := &core.AddressRef{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				f.Value = []string{value}
+			}
+			fields = append(fields, f)
+
+		case "cardRef":
+			f := &core.CardRef{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				f.Value = []string{value}
+			}
+			fields = append(fields, f)
+
+		case "fileRef":
+			// fileRef has no PrivacyScreen in the SDK struct.
+			f := &core.FileRef{KeeperRecordField: base, Required: required}
+			if value != "" {
+				f.Value = []string{value}
+			}
+			fields = append(fields, f)
+
+		case "oneTimeCode":
+			f := &core.OneTimeCode{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				f.Value = []string{value}
 			}
 			fields = append(fields, f)
 

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -292,7 +292,8 @@ func getFieldItemsData(recordDict map[string]interface{}, section string) []inte
 		}
 
 		v, found := item["value"]
-		if found && strings.ToLower(fi["type"].(string)) == "date" {
+		ft := strings.ToLower(fi["type"].(string))
+		if found && (ft == "date" || ft == "birthdate" || ft == "expirationdate") {
 			// TF timestamp() uses RFC3339 we truncate to date parts only
 			if sVals, ok := v.([]interface{}); ok && len(sVals) > 0 {
 				dates := []interface{}{}
@@ -337,12 +338,29 @@ func getFieldItemsData(recordDict map[string]interface{}, section string) []inte
 	return fis
 }
 
+// parseJSONItems accepts either a single JSON object ({"key":"val"}) or a JSON array
+// ([{"key":"val"},{"key":"val2"}]) and returns a slice of raw JSON messages — one per
+// entry. This lets callers write value = jsonencode({...}) for one entry or
+// value = jsonencode([{...},{...}]) for multiple entries without changing the schema.
+func parseJSONItems(value string) ([]json.RawMessage, error) {
+	if strings.TrimSpace(value)[0] == '[' {
+		var items []json.RawMessage
+		return items, json.Unmarshal([]byte(value), &items)
+	}
+	return []json.RawMessage{json.RawMessage(value)}, nil
+}
+
 // customFieldsFromSchema converts the "custom" TypeList from schema into a slice of
 // Keeper SDK field objects suitable for RecordCreate.Custom or RecordUpdate.
 // Each item has type, label, value (string), required, privacy_screen.
-// For complex types (phone, name, address, paymentCard), value must be a JSON string
-// (use jsonencode() in HCL). For date, value accepts RFC3339 or YYYY-MM-DD; the
-// read path always returns YYYY-MM-DD so configs should use that format.
+//
+// Value encoding by type:
+//   - Simple strings (text, multiline, secret, url, email, login, password, etc.): plain string
+//   - Dates (date, birthDate, expirationDate): RFC3339 or YYYY-MM-DD; read always returns YYYY-MM-DD
+//   - Complex objects (phone, name, address, paymentCard, bankAccount, host,
+//     securityQuestion, keyPair, script): jsonencode({...}) for one entry,
+//     jsonencode([{...},{...}]) for multiple entries in the same field
+//   - Unknown types: stored as core.Text (no silent data loss)
 func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 	fields := []interface{}{}
 	for _, item := range items {
@@ -368,7 +386,7 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 			}
 			fields = append(fields, f)
 
-		case "date":
+		case "date", "birthDate", "expirationDate":
 			f := &core.Date{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
 				t, err := time.Parse(time.RFC3339, value)
@@ -386,64 +404,197 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 		case "phone":
 			f := &core.Phones{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
-				var v map[string]interface{}
-				if err := json.Unmarshal([]byte(value), &v); err != nil {
+				items, err := parseJSONItems(value)
+				if err != nil {
 					return nil, fmt.Errorf("custom field %q: invalid JSON for phone value: %w", label, err)
 				}
-				phone := core.Phone{}
-				if s, ok := v["region"].(string); ok { phone.Region = s }
-				if s, ok := v["number"].(string); ok { phone.Number = s }
-				if s, ok := v["ext"].(string); ok { phone.Ext = s }
-				if s, ok := v["type"].(string); ok { phone.Type = s }
-				f.Value = []core.Phone{phone}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for phone entry: %w", label, err)
+					}
+					phone := core.Phone{}
+					if s, ok := v["region"].(string); ok { phone.Region = s }
+					if s, ok := v["number"].(string); ok { phone.Number = s }
+					if s, ok := v["ext"].(string); ok { phone.Ext = s }
+					if s, ok := v["type"].(string); ok { phone.Type = s }
+					f.Value = append(f.Value, phone)
+				}
 			}
 			fields = append(fields, f)
 
 		case "name":
 			f := &core.Names{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
-				var v map[string]interface{}
-				if err := json.Unmarshal([]byte(value), &v); err != nil {
+				items, err := parseJSONItems(value)
+				if err != nil {
 					return nil, fmt.Errorf("custom field %q: invalid JSON for name value: %w", label, err)
 				}
-				name := core.Name{}
-				if s, ok := v["first"].(string); ok { name.First = s }
-				if s, ok := v["middle"].(string); ok { name.Middle = s }
-				if s, ok := v["last"].(string); ok { name.Last = s }
-				f.Value = []core.Name{name}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for name entry: %w", label, err)
+					}
+					name := core.Name{}
+					if s, ok := v["first"].(string); ok { name.First = s }
+					if s, ok := v["middle"].(string); ok { name.Middle = s }
+					if s, ok := v["last"].(string); ok { name.Last = s }
+					f.Value = append(f.Value, name)
+				}
 			}
 			fields = append(fields, f)
 
 		case "address":
 			f := &core.Addresses{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
-				var v map[string]interface{}
-				if err := json.Unmarshal([]byte(value), &v); err != nil {
+				items, err := parseJSONItems(value)
+				if err != nil {
 					return nil, fmt.Errorf("custom field %q: invalid JSON for address value: %w", label, err)
 				}
-				addr := core.Address{}
-				if s, ok := v["street1"].(string); ok { addr.Street1 = s }
-				if s, ok := v["street2"].(string); ok { addr.Street2 = s }
-				if s, ok := v["city"].(string); ok { addr.City = s }
-				if s, ok := v["state"].(string); ok { addr.State = s }
-				if s, ok := v["country"].(string); ok { addr.Country = s }
-				if s, ok := v["zip"].(string); ok { addr.Zip = s }
-				f.Value = []core.Address{addr}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for address entry: %w", label, err)
+					}
+					addr := core.Address{}
+					if s, ok := v["street1"].(string); ok { addr.Street1 = s }
+					if s, ok := v["street2"].(string); ok { addr.Street2 = s }
+					if s, ok := v["city"].(string); ok { addr.City = s }
+					if s, ok := v["state"].(string); ok { addr.State = s }
+					if s, ok := v["country"].(string); ok { addr.Country = s }
+					if s, ok := v["zip"].(string); ok { addr.Zip = s }
+					f.Value = append(f.Value, addr)
+				}
 			}
 			fields = append(fields, f)
 
 		case "paymentCard":
 			f := &core.PaymentCards{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
-				var v map[string]interface{}
-				if err := json.Unmarshal([]byte(value), &v); err != nil {
+				items, err := parseJSONItems(value)
+				if err != nil {
 					return nil, fmt.Errorf("custom field %q: invalid JSON for paymentCard value: %w", label, err)
 				}
-				card := core.PaymentCard{}
-				if s, ok := v["card_number"].(string); ok { card.CardNumber = s }
-				if s, ok := v["card_expiration_date"].(string); ok { card.CardExpirationDate = s }
-				if s, ok := v["card_security_code"].(string); ok { card.CardSecurityCode = s }
-				f.Value = []core.PaymentCard{card}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for paymentCard entry: %w", label, err)
+					}
+					card := core.PaymentCard{}
+					if s, ok := v["card_number"].(string); ok { card.CardNumber = s }
+					if s, ok := v["card_expiration_date"].(string); ok { card.CardExpirationDate = s }
+					if s, ok := v["card_security_code"].(string); ok { card.CardSecurityCode = s }
+					f.Value = append(f.Value, card)
+				}
+			}
+			fields = append(fields, f)
+
+		case "bankAccount":
+			f := &core.BankAccounts{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				items, err := parseJSONItems(value)
+				if err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for bankAccount value: %w", label, err)
+				}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for bankAccount entry: %w", label, err)
+					}
+					acct := core.BankAccount{}
+					if s, ok := v["accountType"].(string); ok { acct.AccountType = s }
+					if s, ok := v["routingNumber"].(string); ok { acct.RoutingNumber = s }
+					if s, ok := v["accountNumber"].(string); ok { acct.AccountNumber = s }
+					if s, ok := v["otherType"].(string); ok { acct.OtherType = s }
+					f.Value = append(f.Value, acct)
+				}
+			}
+			fields = append(fields, f)
+
+		case "host":
+			f := &core.Hosts{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				items, err := parseJSONItems(value)
+				if err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for host value: %w", label, err)
+				}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for host entry: %w", label, err)
+					}
+					h := core.Host{}
+					if s, ok := v["hostName"].(string); ok { h.Hostname = s }
+					if s, ok := v["port"].(string); ok { h.Port = s }
+					f.Value = append(f.Value, h)
+				}
+			}
+			fields = append(fields, f)
+
+		case "securityQuestion":
+			f := &core.SecurityQuestions{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				items, err := parseJSONItems(value)
+				if err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for securityQuestion value: %w", label, err)
+				}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for securityQuestion entry: %w", label, err)
+					}
+					q := core.SecurityQuestion{}
+					if s, ok := v["question"].(string); ok { q.Question = s }
+					if s, ok := v["answer"].(string); ok { q.Answer = s }
+					f.Value = append(f.Value, q)
+				}
+			}
+			fields = append(fields, f)
+
+		case "keyPair":
+			f := &core.KeyPairs{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				items, err := parseJSONItems(value)
+				if err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for keyPair value: %w", label, err)
+				}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for keyPair entry: %w", label, err)
+					}
+					kp := core.KeyPair{}
+					if s, ok := v["publicKey"].(string); ok { kp.PublicKey = s }
+					if s, ok := v["privateKey"].(string); ok { kp.PrivateKey = s }
+					f.Value = append(f.Value, kp)
+				}
+			}
+			fields = append(fields, f)
+
+		case "script":
+			f := &core.Scripts{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
+			if value != "" {
+				items, err := parseJSONItems(value)
+				if err != nil {
+					return nil, fmt.Errorf("custom field %q: invalid JSON for script value: %w", label, err)
+				}
+				for _, raw := range items {
+					var v map[string]interface{}
+					if err := json.Unmarshal(raw, &v); err != nil {
+						return nil, fmt.Errorf("custom field %q: invalid JSON for script entry: %w", label, err)
+					}
+					s := core.Script{}
+					if str, ok := v["fileRef"].(string); ok { s.FileRef = str }
+					if str, ok := v["command"].(string); ok { s.Command = str }
+					if arr, ok := v["recordRef"].([]interface{}); ok {
+						for _, r := range arr {
+							if str, ok := r.(string); ok {
+								s.RecordRef = append(s.RecordRef, str)
+							}
+						}
+					}
+					f.Value = append(f.Value, s)
+				}
 			}
 			fields = append(fields, f)
 

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -298,7 +298,7 @@ func getFieldItemsData(recordDict map[string]interface{}, section string) []inte
 				dates := []interface{}{}
 				for _, date := range sVals {
 					if d, success := date.(float64); success {
-						value := time.Unix(int64(d/1000), 0).Format("2006-01-02") // date only
+						value := time.Unix(int64(d/1000), 0).UTC().Format("2006-01-02") // date only, UTC
 						dates = append(dates, value)
 					}
 				}
@@ -341,7 +341,8 @@ func getFieldItemsData(recordDict map[string]interface{}, section string) []inte
 // Keeper SDK field objects suitable for RecordCreate.Custom or RecordUpdate.
 // Each item has type, label, value (string), required, privacy_screen.
 // For complex types (phone, name, address, paymentCard), value must be a JSON string
-// (use jsonencode() in HCL). For date, value must be RFC3339.
+// (use jsonencode() in HCL). For date, value accepts RFC3339 or YYYY-MM-DD; the
+// read path always returns YYYY-MM-DD so configs should use that format.
 func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 	fields := []interface{}{}
 	for _, item := range items {

--- a/secretsmanager/record_fields.go
+++ b/secretsmanager/record_fields.go
@@ -120,6 +120,7 @@ func schemaAccountNumberField() *schema.Schema {
 				"value": {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: "Field value.",
 				},
 			},
@@ -290,11 +291,13 @@ func schemaBankAccountField() *schema.Schema {
 							"routing_number": {
 								Type:        schema.TypeString,
 								Optional:    true,
+								Sensitive:   true,
 								Description: "Routing number.",
 							},
 							"account_number": {
 								Type:        schema.TypeString,
 								Optional:    true,
+								Sensitive:   true,
 								Description: "Account number.",
 							},
 							"other_type": {
@@ -822,6 +825,7 @@ func schemaLicenseNumberField() *schema.Schema {
 				"value": {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: "Field value.",
 				},
 			},
@@ -1000,6 +1004,7 @@ func schemaOneTimeCodeField() *schema.Schema {
 				"value": {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: "Field value.",
 				},
 			},
@@ -1156,6 +1161,7 @@ func schemaPaymentCardField() *schema.Schema {
 							"card_number": {
 								Type:        schema.TypeString,
 								Optional:    true,
+								Sensitive:   true,
 								Description: "Card number.",
 							},
 							"card_expiration_date": {
@@ -1166,6 +1172,7 @@ func schemaPaymentCardField() *schema.Schema {
 							"card_security_code": {
 								Type:        schema.TypeString,
 								Optional:    true,
+								Sensitive:   true,
 								Description: "Card security code.",
 							},
 						},
@@ -1293,6 +1300,7 @@ func schemaPinCodeField() *schema.Schema {
 				"value": {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: "Field value.",
 				},
 			},
@@ -1332,6 +1340,7 @@ func schemaSecretField() *schema.Schema {
 				"value": {
 					Type:        schema.TypeString,
 					Optional:    true,
+					Sensitive:   true,
 					Description: "Field value.",
 				},
 			},

--- a/secretsmanager/record_fields.go
+++ b/secretsmanager/record_fields.go
@@ -1555,11 +1555,13 @@ func schemaCustomField() *schema.Schema {
 				"required": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Computed:    true,
 					Description: "Whether this field is required.",
 				},
 				"privacy_screen": {
 					Type:        schema.TypeBool,
 					Optional:    true,
+					Computed:    true,
 					Description: "Whether this field is hidden behind a privacy screen in the Keeper UI.",
 				},
 			},

--- a/secretsmanager/record_fields.go
+++ b/secretsmanager/record_fields.go
@@ -1522,3 +1522,47 @@ func schemaUrlField() *schema.Schema {
 		},
 	}
 }
+
+// schemaCustomField returns the schema for user-defined custom fields on a record.
+// Each field has a type, label, and value. The value is always a string:
+// - Simple types (text, multiline, secret, url, email): plain string value
+// - Complex types (phone, name, address, paymentCard): jsonencode() of the nested object
+// - Date: RFC3339 string (e.g. "2024-01-15T00:00:00Z")
+// The provider interprets the value based on the type field.
+func schemaCustomField() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Optional:    true,
+		Description: "Custom fields defined by the user in Keeper. Each field has a type, label, and value.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Field type (e.g. text, secret, url, email, multiline, date, phone, name, address, paymentCard).",
+				},
+				"label": {
+					Type:        schema.TypeString,
+					Required:    true,
+					Description: "Field label. Used to identify the field within the record.",
+				},
+				"value": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Sensitive:   true,
+					Description: "Field value. Use a plain string for simple types. Use jsonencode() for complex types (phone, name, address, paymentCard).",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Whether this field is required.",
+				},
+				"privacy_screen": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Whether this field is hidden behind a privacy screen in the Keeper UI.",
+				},
+			},
+		},
+	}
+}

--- a/secretsmanager/resource_address.go
+++ b/secretsmanager/resource_address.go
@@ -54,6 +54,8 @@ func resourceAddress() *schema.Resource {
 			// fields[]
 			"address":  schemaAddressField(),
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -103,6 +105,14 @@ func resourceAddressCreate(ctx context.Context, d *schema.ResourceData, m interf
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -194,6 +204,11 @@ func resourceAddressRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -237,6 +252,15 @@ func resourceAddressUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_bank_account.go
+++ b/secretsmanager/resource_bank_account.go
@@ -60,6 +60,8 @@ func resourceBankAccount() *schema.Resource {
 			"card_ref":     schemaCardRefField(),
 			"totp":         schemaOneTimeCodeField(),
 			"file_ref":     schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -179,6 +181,14 @@ func resourceBankAccountCreate(ctx context.Context, d *schema.ResourceData, m in
 		}
 	}
 
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
+		}
+	}
+
 	if folderUid == "*" {
 		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
 			return diag.FromErr(err)
@@ -292,6 +302,11 @@ func resourceBankAccountRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -365,6 +380,15 @@ func resourceBankAccountUpdate(ctx context.Context, d *schema.ResourceData, m in
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_bank_account_test.go
+++ b/secretsmanager/resource_bank_account_test.go
@@ -246,3 +246,76 @@ func TestAccResourceBankAccount_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourceBankAccount_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_bank_account_custom"
+
+	configCreate := fmt.Sprintf(`
+		resource "secretsmanager_bank_account" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Branch"
+				value = "Downtown"
+			}
+			custom {
+				type  = "text"
+				label = "AccountTier"
+				value = "Premium"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	configUpdate := fmt.Sprintf(`
+		resource "secretsmanager_bank_account" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Branch"
+				value = "Uptown"
+			}
+			custom {
+				type  = "text"
+				label = "AccountTier"
+				value = "Premium"
+			}
+			custom {
+				type  = "text"
+				label = "CurrencyCode"
+				value = "USD"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_bank_account.custom", "custom.#", "2"),
+					resource.TestCheckResourceAttr("secretsmanager_bank_account.custom", "custom.0.label", "Branch"),
+					resource.TestCheckResourceAttr("secretsmanager_bank_account.custom", "custom.0.value", "Downtown"),
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("secretsmanager_bank_account.custom", "custom.#", "3"),
+					resource.TestCheckResourceAttr("secretsmanager_bank_account.custom", "custom.0.value", "Uptown"),
+					resource.TestCheckResourceAttr("secretsmanager_bank_account.custom", "custom.2.label", "CurrencyCode"),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/resource_bank_card.go
+++ b/secretsmanager/resource_bank_card.go
@@ -57,6 +57,8 @@ func resourceBankCard() *schema.Resource {
 			"pin_code":        schemaPinCodeField(),
 			"address_ref":     schemaAddressRefField(),
 			"file_ref":        schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -136,6 +138,14 @@ func resourceBankCardCreate(ctx context.Context, d *schema.ResourceData, m inter
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -239,6 +249,11 @@ func resourceBankCardRead(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -297,6 +312,15 @@ func resourceBankCardUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_birth_certificate.go
+++ b/secretsmanager/resource_birth_certificate.go
@@ -55,6 +55,8 @@ func resourceBirthCertificate() *schema.Resource {
 			"name":       schemaNameField(),
 			"birth_date": schemaBirthDateField(),
 			"file_ref":   schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -114,6 +116,14 @@ func resourceBirthCertificateCreate(ctx context.Context, d *schema.ResourceData,
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -209,6 +219,11 @@ func resourceBirthCertificateRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -257,6 +272,15 @@ func resourceBirthCertificateUpdate(ctx context.Context, d *schema.ResourceData,
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_contact.go
+++ b/secretsmanager/resource_contact.go
@@ -58,6 +58,8 @@ func resourceContact() *schema.Resource {
 			"phone":       schemaPhoneField(),
 			"address_ref": schemaAddressRefField(),
 			"file_ref":    schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -147,6 +149,14 @@ func resourceContactCreate(ctx context.Context, d *schema.ResourceData, m interf
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -254,6 +264,11 @@ func resourceContactRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -317,6 +332,15 @@ func resourceContactUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_database_credentials.go
+++ b/secretsmanager/resource_database_credentials.go
@@ -57,6 +57,8 @@ func resourceDatabaseCredentials() *schema.Resource {
 			"password": schemaPasswordField(""),
 			"host":     schemaHostField(),
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -143,6 +145,14 @@ func resourceDatabaseCredentialsCreate(ctx context.Context, d *schema.ResourceDa
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -247,6 +257,11 @@ func resourceDatabaseCredentialsRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -305,6 +320,15 @@ func resourceDatabaseCredentialsUpdate(ctx context.Context, d *schema.ResourceDa
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_driver_license.go
+++ b/secretsmanager/resource_driver_license.go
@@ -58,6 +58,8 @@ func resourceDriverLicense() *schema.Resource {
 			"expiration_date":       schemaExpirationDateField(),
 			"address_ref":           schemaAddressRefField(),
 			"file_ref":              schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -147,6 +149,14 @@ func resourceDriverLicenseCreate(ctx context.Context, d *schema.ResourceData, m 
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -254,6 +264,11 @@ func resourceDriverLicenseRead(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -317,6 +332,15 @@ func resourceDriverLicenseUpdate(ctx context.Context, d *schema.ResourceData, m 
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_encrypted_notes.go
+++ b/secretsmanager/resource_encrypted_notes.go
@@ -55,6 +55,8 @@ func resourceEncryptedNotes() *schema.Resource {
 			"note":     schemaSecureNoteField(),
 			"date":     schemaDateField(),
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -114,6 +116,14 @@ func resourceEncryptedNotesCreate(ctx context.Context, d *schema.ResourceData, m
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -209,6 +219,11 @@ func resourceEncryptedNotesRead(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -257,6 +272,15 @@ func resourceEncryptedNotesUpdate(ctx context.Context, d *schema.ResourceData, m
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_encrypted_notes_test.go
+++ b/secretsmanager/resource_encrypted_notes_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/keeper-security/secrets-manager-go/core"
 )
 
+
 func TestAccResourceEncryptedNotes_create(t *testing.T) {
 	secretType := "encryptedNotes"
 	secretFolderUid := testAcc.getTestFolder()
@@ -194,6 +195,42 @@ func TestAccResourceEncryptedNotes_import(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceEncryptedNotes_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_encrypted_notes_custom"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_encrypted_notes" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Classification"
+				value = "confidential"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_encrypted_notes.custom", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_encrypted_notes.custom", "custom.0.label", "Classification"),
+					resource.TestCheckResourceAttr("secretsmanager_encrypted_notes.custom", "custom.0.value", "confidential"),
+				),
 			},
 		},
 	})

--- a/secretsmanager/resource_file.go
+++ b/secretsmanager/resource_file.go
@@ -53,6 +53,8 @@ func resourceFile() *schema.Resource {
 			},
 			// fields[]
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -91,6 +93,14 @@ func resourceFileCreate(ctx context.Context, d *schema.ResourceData, m interface
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -177,6 +187,11 @@ func resourceFileRead(ctx context.Context, d *schema.ResourceData, m interface{}
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -214,6 +229,15 @@ func resourceFileUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_health_insurance.go
+++ b/secretsmanager/resource_health_insurance.go
@@ -58,6 +58,8 @@ func resourceHealthInsurance() *schema.Resource {
 			"password":       schemaPasswordField(""),
 			"url":            schemaUrlField(),
 			"file_ref":       schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -154,6 +156,14 @@ func resourceHealthInsuranceCreate(ctx context.Context, d *schema.ResourceData, 
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -262,6 +272,11 @@ func resourceHealthInsuranceRead(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -325,6 +340,15 @@ func resourceHealthInsuranceUpdate(ctx context.Context, d *schema.ResourceData, 
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_login.go
+++ b/secretsmanager/resource_login.go
@@ -57,6 +57,8 @@ func resourceLogin() *schema.Resource {
 			"url":      schemaUrlField(),
 			"totp":     schemaOneTimeCodeField(),
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -143,6 +145,14 @@ func resourceLoginCreate(ctx context.Context, d *schema.ResourceData, m interfac
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -247,6 +257,11 @@ func resourceLoginRead(ctx context.Context, d *schema.ResourceData, m interface{
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -305,6 +320,15 @@ func resourceLoginUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -525,14 +525,22 @@ func TestAccResourceLogin_customFieldAddress(t *testing.T) {
 	})
 }
 
-// TestAccResourceLogin_customFieldPaymentCard tests the paymentCard complex type.
-func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
+// TestAccResourceLogin_customFieldPaymentCardRoundTrip is the regression test for KSM-888:
+// paymentCard keys must use camelCase (cardNumber, cardExpirationDate, cardSecurityCode)
+// to match what the read path serializes via toJsonDefault() / json.Marshal on the SDK
+// struct. The original write path read snake_case keys (card_number, card_expiration_date,
+// card_security_code), which never matched any real key in the user's jsonencode output,
+// causing the card to be written empty and a perpetual plan diff on every apply.
+//
+// Failure mode before fix: PlanOnly step detects diff (state "{}"; config has card data).
+// Passing mode after fix: both write and read use camelCase; round-trip is stable.
+func TestAccResourceLogin_customFieldPaymentCardRoundTrip(t *testing.T) {
 	secretFolderUid := testAcc.getTestFolder()
 	secretUid := core.GenerateUid()
-	secretTitle := "tf_acc_custom_payment_card"
+	secretTitle := "tf_acc_custom_payment_card_rt"
 
 	config := fmt.Sprintf(`
-		resource "secretsmanager_login" "custom_payment_card" {
+		resource "secretsmanager_login" "custom_payment_card_rt" {
 			folder_uid = "%v"
 			uid        = "%v"
 			title      = "%v"
@@ -541,9 +549,9 @@ func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
 				type  = "paymentCard"
 				label = "Corporate Card"
 				value = jsonencode({
-					card_number          = "4111111111111111"
-					card_expiration_date = "12/2027"
-					card_security_code   = "123"
+					cardNumber         = "4111111111111111"
+					cardExpirationDate = "12/2027"
+					cardSecurityCode   = "123"
 				})
 			}
 		}
@@ -557,13 +565,16 @@ func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					checkSecretExistsRemotely(secretUid),
-					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.#", "1"),
-					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.0.type", "paymentCard"),
-					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.0.label", "Corporate Card"),
-					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_payment_card", "custom.0.value"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card_rt", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card_rt", "custom.0.type", "paymentCard"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card_rt", "custom.0.label", "Corporate Card"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_payment_card_rt", "custom.0.value"),
 				),
 			},
 			{
+				// Regression guard: state must equal config — no perpetual diff.
+				// Before fix: write path read card_number (snake_case, not found) →
+				// wrote empty card → read back "{}" → diff on every plan.
 				Config:   config,
 				PlanOnly: true,
 			},

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -609,6 +609,95 @@ func TestAccResourceLogin_customFieldDate(t *testing.T) {
 	})
 }
 
+// TestAccResourceLogin_customFieldImportAndComputedMetadata tests two related things:
+//
+//  1. Import: a login resource with custom fields that have required=true and
+//     privacy_screen=true can be imported and all fields round-trip correctly.
+//
+//  2. No perpetual diff: after import (or create), a config that OMITS required
+//     and privacy_screen produces no plan diff. This is the regression guard for
+//     the Computed: true fix — without it, every plan would show a diff because
+//     Terraform would treat the omitted field as "set to false" vs vault's "true".
+func TestAccResourceLogin_customFieldImportAndComputedMetadata(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_import"
+	resourceName := "secretsmanager_login.custom_import"
+
+	// configExplicit sets required and privacy_screen explicitly.
+	// This is what creates the vault record with those flags set.
+	configExplicit := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_import" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type           = "text"
+				label          = "Environment"
+				value          = "production"
+				required       = true
+				privacy_screen = true
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	// configOmitted is identical but omits required and privacy_screen entirely.
+	// With Computed: true, Terraform should accept the vault values and show no diff.
+	configOmitted := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_import" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Environment"
+				value = "production"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with explicit required/privacy_screen
+				Config: configExplicit,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr(resourceName, "custom.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "custom.0.type", "text"),
+					resource.TestCheckResourceAttr(resourceName, "custom.0.label", "Environment"),
+					resource.TestCheckResourceAttr(resourceName, "custom.0.required", "true"),
+					resource.TestCheckResourceAttr(resourceName, "custom.0.privacy_screen", "true"),
+				),
+			},
+			{
+				// Step 2: import by UID — verify all fields including required and
+				// privacy_screen round-trip correctly from the vault.
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// value is Sensitive: true — Terraform stores it in state but masks
+				// it in output. ImportStateVerify compares raw state values, so it
+				// should still match. If the vault returns the value in a different
+				// format after import, add it to ImportStateVerifyIgnore.
+			},
+			{
+				// Step 3: PlanOnly with config that OMITS required and privacy_screen.
+				// This is the perpetual-diff regression guard: if Computed: true is
+				// working correctly, omitting these fields in HCL should produce no
+				// diff (vault values are authoritative). If Computed were missing,
+				// Terraform would want to set them to false on every plan.
+				Config:   configOmitted,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestAccResourceLogin_customFieldKeyPair tests the keyPair complex type.
 // A real ed25519 key pair is generated in-process and injected into the config
 // so we verify actual key material round-trips correctly through the vault.

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -1,0 +1,412 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+// TestAccResourceLogin_customFieldSimple tests create, read, update, and delete
+// of simple-type custom fields (text, secret) on a login resource.
+func TestAccResourceLogin_customFieldSimple(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_simple"
+
+	configCreate := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_simple" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Environment"
+				value = "production"
+			}
+			custom {
+				type  = "secret"
+				label = "ApiKey"
+				value = "hunter2"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	configUpdate := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_simple" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Environment"
+				value = "staging"
+			}
+			custom {
+				type  = "secret"
+				label = "ApiKey"
+				value = "hunter2"
+			}
+			custom {
+				type  = "text"
+				label = "Region"
+				value = "us-east-1"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.#", "2"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.0.label", "Environment"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.0.value", "production"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.1.label", "ApiKey"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.1.value", "hunter2"),
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.#", "3"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.0.value", "staging"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.2.label", "Region"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple", "custom.2.value", "us-east-1"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldPhone tests a complex phone custom field
+// using jsonencode() for the value.
+func TestAccResourceLogin_customFieldPhone(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_phone"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_phone" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "phone"
+				label = "WorkPhone"
+				value = jsonencode({
+					region = "US"
+					number = "555-867-5309"
+					ext    = "42"
+					type   = "Work"
+				})
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_phone", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_phone", "custom.0.label", "WorkPhone"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_phone", "custom.0.type", "phone"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldMultiValuePhone tests a phone field with two entries
+// using the jsonencode([{...},{...}]) array syntax, and verifies no perpetual diff.
+func TestAccResourceLogin_customFieldMultiValuePhone(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_multi_phone"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_multi_phone" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "phone"
+				label = "ContactNumbers"
+				value = jsonencode([
+					{ region = "US", number = "555-1234", type = "Work" },
+					{ region = "US", number = "555-5678", type = "Mobile" }
+				])
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_multi_phone", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_multi_phone", "custom.0.type", "phone"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_multi_phone", "custom.0.label", "ContactNumbers"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_multi_phone", "custom.0.value"),
+				),
+			},
+			{
+				// Verify no perpetual diff — multi-value round-trip must be stable
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldSecurityQuestion tests a securityQuestion field
+// using jsonencode({question, answer}).
+func TestAccResourceLogin_customFieldSecurityQuestion(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_secq"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_secq" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "securityQuestion"
+				label = "RecoveryQuestion"
+				value = jsonencode({
+					question = "What was the name of your first pet?"
+					answer   = "Fluffy"
+				})
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_secq", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_secq", "custom.0.type", "securityQuestion"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_secq", "custom.0.label", "RecoveryQuestion"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_secq", "custom.0.value"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldCheckbox tests a checkbox field, verifying that
+// the bool value round-trips correctly as "true"/"false" string in state.
+func TestAccResourceLogin_customFieldCheckbox(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_checkbox"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_checkbox" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "checkbox"
+				label = "MFAEnabled"
+				value = "true"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_checkbox", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_checkbox", "custom.0.type", "checkbox"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_checkbox", "custom.0.label", "MFAEnabled"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_checkbox", "custom.0.value", "true"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldBirthDate tests birthDate and expirationDate variants,
+// which share the same []int64 millisecond structure as date but were previously missing
+// from the date-to-YYYY-MM-DD conversion in the read path.
+func TestAccResourceLogin_customFieldBirthDate(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_birthdate"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_birthdate" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "birthDate"
+				label = "DateOfBirth"
+				value = "1990-05-15"
+			}
+			custom {
+				type  = "expirationDate"
+				label = "LicenseExpiry"
+				value = "2027-12-31"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_birthdate", "custom.#", "2"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_birthdate", "custom.0.type", "birthDate"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_birthdate", "custom.0.value", "1990-05-15"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_birthdate", "custom.1.type", "expirationDate"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_birthdate", "custom.1.value", "2027-12-31"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldHostAndBankAccount tests host and bankAccount types,
+// both of which are structured object types added in the expanded type coverage pass.
+func TestAccResourceLogin_customFieldHostAndBankAccount(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_host_bank"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_host_bank" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "host"
+				label = "PrimaryDB"
+				value = jsonencode({
+					hostName = "db.example.com"
+					port     = "5432"
+				})
+			}
+			custom {
+				type  = "bankAccount"
+				label = "Escrow"
+				value = jsonencode({
+					accountType   = "Checking"
+					routingNumber = "021000021"
+					accountNumber = "9876543210"
+				})
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_host_bank", "custom.#", "2"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_host_bank", "custom.0.type", "host"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_host_bank", "custom.0.label", "PrimaryDB"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_host_bank", "custom.0.value"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_host_bank", "custom.1.type", "bankAccount"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_host_bank", "custom.1.label", "Escrow"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_host_bank", "custom.1.value"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldDate tests a date custom field using YYYY-MM-DD format.
+// RFC3339 is also accepted on write but the read path always returns YYYY-MM-DD.
+func TestAccResourceLogin_customFieldDate(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_date"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_date" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "date"
+				label = "ExpiresAt"
+				value = "2025-06-01"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_date", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_date", "custom.0.label", "ExpiresAt"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_date", "custom.0.type", "date"),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -1,6 +1,7 @@
 package secretsmanager
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -373,6 +374,203 @@ func TestAccResourceLogin_customFieldHostAndBankAccount(t *testing.T) {
 	})
 }
 
+// TestAccResourceLogin_customFieldSimpleVariants tests simple string types that share
+// the core.Text write path: url, email, and multiline.
+func TestAccResourceLogin_customFieldSimpleVariants(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_simple_variants"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_simple_variants" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "url"
+				label = "Dashboard"
+				value = "https://example.com/dashboard"
+			}
+			custom {
+				type  = "email"
+				label = "Alerts"
+				value = "alerts@example.com"
+			}
+			custom {
+				type  = "multiline"
+				label = "Notes"
+				value = "line one\nline two"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.#", "3"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.0.type", "url"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.0.value", "https://example.com/dashboard"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.1.type", "email"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.1.value", "alerts@example.com"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.2.type", "multiline"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_simple_variants", "custom.2.value", "line one\nline two"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldName tests the name complex type (first/middle/last).
+func TestAccResourceLogin_customFieldName(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_name"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_name" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "name"
+				label = "Owner"
+				value = jsonencode({
+					first  = "Jane"
+					middle = "Q"
+					last   = "Doe"
+				})
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_name", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_name", "custom.0.type", "name"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_name", "custom.0.label", "Owner"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_name", "custom.0.value"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldAddress tests the address complex type.
+func TestAccResourceLogin_customFieldAddress(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_address"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_address" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "address"
+				label = "HQ"
+				value = jsonencode({
+					street1 = "123 Main St"
+					street2 = "Suite 400"
+					city    = "San Francisco"
+					state   = "CA"
+					country = "US"
+					zip     = "94105"
+				})
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_address", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_address", "custom.0.type", "address"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_address", "custom.0.label", "HQ"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_address", "custom.0.value"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldPaymentCard tests the paymentCard complex type.
+func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_payment_card"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_payment_card" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "paymentCard"
+				label = "Corporate Card"
+				value = jsonencode({
+					card_number          = "4111111111111111"
+					card_expiration_date = "12/2027"
+					card_security_code   = "123"
+				})
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.0.type", "paymentCard"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.0.label", "Corporate Card"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_payment_card", "custom.0.value"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // TestAccResourceLogin_customFieldDate tests a date custom field using YYYY-MM-DD format.
 // RFC3339 is also accepted on write but the read path always returns YYYY-MM-DD.
 func TestAccResourceLogin_customFieldDate(t *testing.T) {
@@ -406,6 +604,65 @@ func TestAccResourceLogin_customFieldDate(t *testing.T) {
 					resource.TestCheckResourceAttr("secretsmanager_login.custom_date", "custom.0.label", "ExpiresAt"),
 					resource.TestCheckResourceAttr("secretsmanager_login.custom_date", "custom.0.type", "date"),
 				),
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldKeyPair tests the keyPair complex type.
+// A real ed25519 key pair is generated in-process and injected into the config
+// so we verify actual key material round-trips correctly through the vault.
+func TestAccResourceLogin_customFieldKeyPair(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_keypair"
+
+	kp, err := GenerateSSHKeyPair(SSHKeyTypeED25519, 0, "")
+	if err != nil {
+		t.Fatalf("failed to generate key pair for test: %v", err)
+	}
+
+	// Marshal to JSON so newlines and special chars are properly escaped
+	// for embedding as an HCL string literal.
+	valueJSON, err := json.Marshal(map[string]string{
+		"publicKey":  kp.PublicKey,
+		"privateKey": kp.PrivateKey,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal key pair to JSON: %v", err)
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_keypair" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "keyPair"
+				label = "DeployKey"
+				value = %q
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle, string(valueJSON))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_keypair", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_keypair", "custom.0.type", "keyPair"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_keypair", "custom.0.label", "DeployKey"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_keypair", "custom.0.value"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
 			},
 		},
 	})

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -3,6 +3,7 @@ package secretsmanager
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -583,7 +584,7 @@ func TestAccResourceLogin_customFieldPaymentCardRoundTrip(t *testing.T) {
 }
 
 // TestAccResourceLogin_customFieldDate tests a date custom field using YYYY-MM-DD format.
-// RFC3339 is also accepted on write but the read path always returns YYYY-MM-DD.
+// Only YYYY-MM-DD is accepted — RFC3339 is rejected with a clear error (KSM-889).
 func TestAccResourceLogin_customFieldDate(t *testing.T) {
 	secretFolderUid := testAcc.getTestFolder()
 	secretUid := core.GenerateUid()
@@ -763,6 +764,86 @@ func TestAccResourceLogin_customFieldKeyPair(t *testing.T) {
 			{
 				Config:   config,
 				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldCheckboxInvalidInput is the regression test for KSM-889
+// (checkbox). Values like "yes", "1", "on" were silently treated as false — because
+// strings.ToLower(value) == "true" is false for them — then read back as "false", causing
+// a perpetual diff between config and state.
+//
+// After KSM-889: apply returns an error immediately, directing the user to use "true" or "false".
+// Failure mode before fix: no error raised → ExpectError step fails (expected error, got none).
+// Passing mode after fix: error raised → ExpectError step passes.
+func TestAccResourceLogin_customFieldCheckboxInvalidInput(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_checkbox_invalid"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_checkbox_invalid" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "checkbox"
+				label = "Feature"
+				value = "yes"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`invalid checkbox value`),
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldDateInvalidFormat is the regression test for KSM-889
+// (date). RFC3339 values like "2026-03-20T14:30:00Z" were silently accepted, stored as
+// epoch ms, but the read path always returned "2026-03-20" (YYYY-MM-DD only, time
+// component discarded). This caused a perpetual diff: config kept the RFC3339 string
+// while state showed YYYY-MM-DD.
+//
+// After KSM-889: apply returns an error immediately, directing the user to use YYYY-MM-DD.
+// Applies equally to date, birthDate, and expirationDate — all share the same write path.
+// Failure mode before fix: no error raised → ExpectError step fails (expected error, got none).
+// Passing mode after fix: error raised → ExpectError step passes.
+func TestAccResourceLogin_customFieldDateInvalidFormat(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_date_invalid"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_date_invalid" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "date"
+				label = "Review"
+				value = "2026-03-20T14:30:00Z"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`invalid date value`),
 			},
 		},
 	})

--- a/secretsmanager/resource_membership.go
+++ b/secretsmanager/resource_membership.go
@@ -56,6 +56,8 @@ func resourceMembership() *schema.Resource {
 			"name":           schemaNameField(),
 			"password":       schemaPasswordField(""),
 			"file_ref":       schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -132,6 +134,14 @@ func resourceMembershipCreate(ctx context.Context, d *schema.ResourceData, m int
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -232,6 +242,11 @@ func resourceMembershipRead(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -285,6 +300,15 @@ func resourceMembershipUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_pam_database.go
+++ b/secretsmanager/resource_pam_database.go
@@ -63,6 +63,8 @@ func resourcePamDatabase() *schema.Resource {
 			"provider_region":  schemaTextField(),
 			"file_ref":         schemaFileRefField(),
 			"totp":             schemaOneTimeCodeField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -195,6 +197,14 @@ func resourcePamDatabaseCreate(ctx context.Context, d *schema.ResourceData, m in
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -332,6 +342,11 @@ func resourcePamDatabaseRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -452,6 +467,16 @@ func resourcePamDatabaseUpdate(ctx context.Context, d *schema.ResourceData, m in
 		}
 	}
 
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
+	}
+
+	secret.RawJson = core.DictToJson(secret.RecordDict)
 	if err := saveRecord(secret, client); err != nil {
 		return diag.FromErr(err)
 	}

--- a/secretsmanager/resource_pam_database_test.go
+++ b/secretsmanager/resource_pam_database_test.go
@@ -248,3 +248,42 @@ func TestAccResourcePamDatabase_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourcePamDatabase_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_database_custom"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_database" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Environment"
+				value = "staging"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_pam_database.custom", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_database.custom", "custom.0.label", "Environment"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_database.custom", "custom.0.value", "staging"),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/resource_pam_directory.go
+++ b/secretsmanager/resource_pam_directory.go
@@ -67,6 +67,8 @@ func resourcePamDirectory() *schema.Resource {
 			"alternative_ips":    schemaMultilineField(),
 			"file_ref":           schemaFileRefField(),
 			"totp":               schemaOneTimeCodeField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -247,6 +249,14 @@ func resourcePamDirectoryCreate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
+		}
+	}
+
 	if folderUid == "*" {
 		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
 			return diag.FromErr(err)
@@ -397,6 +407,11 @@ func resourcePamDirectoryRead(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -537,6 +552,16 @@ func resourcePamDirectoryUpdate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
+	}
+
+	secret.RawJson = core.DictToJson(secret.RecordDict)
 	if err := saveRecord(secret, client); err != nil {
 		return diag.FromErr(err)
 	}

--- a/secretsmanager/resource_pam_directory_test.go
+++ b/secretsmanager/resource_pam_directory_test.go
@@ -281,3 +281,42 @@ func TestAccResourcePamDirectory_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourcePamDirectory_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_directory_custom"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_directory" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Department"
+				value = "engineering"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_pam_directory.custom", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_directory.custom", "custom.0.label", "Department"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_directory.custom", "custom.0.value", "engineering"),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/resource_pam_machine.go
+++ b/secretsmanager/resource_pam_machine.go
@@ -68,6 +68,8 @@ func resourcePamMachine() *schema.Resource {
 			"provider_region":        schemaTextField(),
 			"file_ref":               schemaFileRefField(),
 			"totp":                   schemaOneTimeCodeField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -296,6 +298,16 @@ func resourcePamMachineCreate(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
+	// User-defined custom fields — appended after the platform-managed
+	// "Private Key Passphrase" entry already placed in nrc.Custom above.
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = append(nrc.Custom, fields...)
+		}
+	}
+
 	if folderUid == "*" {
 		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
 			return diag.FromErr(err)
@@ -445,6 +457,22 @@ func resourcePamMachineRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	fileItems := getFileItemsResourceData(secret)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	// "Private Key Passphrase" is a platform-managed entry in the custom section.
+	// Exclude it from user-visible state to prevent a perpetual diff.
+	allCustom := getFieldItemsData(secret.RecordDict, "custom")
+	userCustom := make([]interface{}, 0, len(allCustom))
+	for _, item := range allCustom {
+		if m, ok := item.(map[string]interface{}); ok {
+			if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+				continue
+			}
+		}
+		userCustom = append(userCustom, item)
+	}
+	if err := d.Set("custom", userCustom); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -625,6 +653,28 @@ func resourcePamMachineUpdate(ctx context.Context, d *schema.ResourceData, m int
 		}
 	}
 
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		userFields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// Preserve "Private Key Passphrase" from the current vault state;
+		// replace all other custom entries with the user-defined fields.
+		var preserved []interface{}
+		if current, ok := secret.RecordDict["custom"].([]interface{}); ok {
+			for _, item := range current {
+				if m, ok := item.(map[string]interface{}); ok {
+					if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+						preserved = append(preserved, item)
+					}
+				}
+			}
+		}
+		secret.RecordDict["custom"] = append(preserved, customFieldsToDict(userFields)...)
+	}
+
+	secret.RawJson = core.DictToJson(secret.RecordDict)
 	if err := saveRecord(secret, client); err != nil {
 		return diag.FromErr(err)
 	}

--- a/secretsmanager/resource_pam_machine_test.go
+++ b/secretsmanager/resource_pam_machine_test.go
@@ -334,6 +334,96 @@ func TestAccResourcePamMachine_generatePrivatePemKey(t *testing.T) {
 	})
 }
 
+// TestAccResourcePamMachine_customField verifies that:
+//  1. A user-defined custom field can be set alongside private_key_passphrase
+//  2. The passphrase does NOT appear in the user-visible custom list (filtered from state)
+//  3. Updating the custom field does not wipe the passphrase from the vault
+func TestAccResourcePamMachine_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_machine_custom"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	configCreate := fmt.Sprintf(`
+		resource "secretsmanager_pam_machine" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			private_key_passphrase {
+				value = "s3cr3tpassphrase"
+			}
+
+			custom {
+				type  = "text"
+				label = "Owner"
+				value = "infra-team"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	configUpdate := fmt.Sprintf(`
+		resource "secretsmanager_pam_machine" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			private_key_passphrase {
+				value = "s3cr3tpassphrase"
+			}
+
+			custom {
+				type  = "text"
+				label = "Owner"
+				value = "platform-team"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					// user custom field is visible
+					resource.TestCheckResourceAttr("secretsmanager_pam_machine.custom", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_machine.custom", "custom.0.label", "Owner"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_machine.custom", "custom.0.value", "infra-team"),
+					// passphrase is NOT in the custom list
+					checkSecretResourceState("secretsmanager_pam_machine.custom", func(s *terraform.InstanceState) error {
+						for k, v := range s.Attributes {
+							if v == "Private Key Passphrase" && k != "private_key_passphrase.0.type" {
+								return fmt.Errorf("passphrase label leaked into custom list at key %s", k)
+							}
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					// custom field updated
+					resource.TestCheckResourceAttr("secretsmanager_pam_machine.custom", "custom.0.value", "platform-team"),
+					// passphrase still present (update did not wipe it)
+					checkSecretResourceState("secretsmanager_pam_machine.custom", func(s *terraform.InstanceState) error {
+						passphrase := s.Attributes["private_key_passphrase.0.value"]
+						if passphrase == "" {
+							return fmt.Errorf("private_key_passphrase was wiped by custom field update")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourcePamMachine_generatePrivatePemKeyWithPassphrase(t *testing.T) {
 	secretFolderUid := testAcc.getTestFolder()
 	secretUid := core.GenerateUid()

--- a/secretsmanager/resource_pam_remote_browser.go
+++ b/secretsmanager/resource_pam_remote_browser.go
@@ -66,6 +66,8 @@ func resourcePamRemoteBrowser() *schema.Resource {
 			"traffic_encryption_seed": schemaTextField(),
 			"file_ref":                schemaFileRefField(),
 			"totp":                    schemaOneTimeCodeField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -193,6 +195,14 @@ func resourcePamRemoteBrowserCreate(ctx context.Context, d *schema.ResourceData,
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -337,6 +347,11 @@ func resourcePamRemoteBrowserRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -403,6 +418,16 @@ func resourcePamRemoteBrowserUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
+	}
+
+	secret.RawJson = core.DictToJson(secret.RecordDict)
 	if err := saveRecord(secret, client); err != nil {
 		return diag.FromErr(err)
 	}

--- a/secretsmanager/resource_pam_remote_browser_test.go
+++ b/secretsmanager/resource_pam_remote_browser_test.go
@@ -122,3 +122,42 @@ func TestAccResourcePamRemoteBrowser_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccResourcePamRemoteBrowser_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_remote_browser_custom"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_remote_browser" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Owner"
+				value = "infra-team"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_pam_remote_browser.custom", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_remote_browser.custom", "custom.0.label", "Owner"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_remote_browser.custom", "custom.0.value", "infra-team"),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/resource_pam_user.go
+++ b/secretsmanager/resource_pam_user.go
@@ -62,6 +62,8 @@ func resourcePamUser() *schema.Resource {
 			"managed":                schemaCheckboxField(),
 			"file_ref":               schemaFileRefField(),
 			"totp":                   schemaOneTimeCodeField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -243,6 +245,16 @@ func resourcePamUserCreate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	}
 
+	// User-defined custom fields — appended after the platform-managed
+	// "Private Key Passphrase" entry already placed in nrc.Custom above.
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = append(nrc.Custom, fields...)
+		}
+	}
+
 	if folderUid == "*" {
 		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
 			return diag.FromErr(err)
@@ -371,6 +383,22 @@ func resourcePamUserRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(err)
 	}
 
+	// "Private Key Passphrase" is a platform-managed entry in the custom section.
+	// Exclude it from user-visible state to prevent a perpetual diff.
+	allCustom := getFieldItemsData(secret.RecordDict, "custom")
+	userCustom := make([]interface{}, 0, len(allCustom))
+	for _, item := range allCustom {
+		if m, ok := item.(map[string]interface{}); ok {
+			if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+				continue
+			}
+		}
+		userCustom = append(userCustom, item)
+	}
+	if err := d.Set("custom", userCustom); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -496,6 +524,28 @@ func resourcePamUserUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	}
 
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		userFields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// Preserve "Private Key Passphrase" from the current vault state;
+		// replace all other custom entries with the user-defined fields.
+		var preserved []interface{}
+		if current, ok := secret.RecordDict["custom"].([]interface{}); ok {
+			for _, item := range current {
+				if m, ok := item.(map[string]interface{}); ok {
+					if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+						preserved = append(preserved, item)
+					}
+				}
+			}
+		}
+		secret.RecordDict["custom"] = append(preserved, customFieldsToDict(userFields)...)
+	}
+
+	secret.RawJson = core.DictToJson(secret.RecordDict)
 	if err := saveRecord(secret, client); err != nil {
 		return diag.FromErr(err)
 	}

--- a/secretsmanager/resource_pam_user_test.go
+++ b/secretsmanager/resource_pam_user_test.go
@@ -342,3 +342,93 @@ func TestAccResourcePamUser_generatePrivatePemKeyWithPassphrase(t *testing.T) {
 		},
 	})
 }
+
+// TestAccResourcePamUser_customField verifies that:
+//  1. A user-defined custom field can be set alongside private_key_passphrase
+//  2. The passphrase does NOT appear in the user-visible custom list (filtered from state)
+//  3. Updating the custom field does not wipe the passphrase from the vault
+func TestAccResourcePamUser_customField(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_test_pam_user_custom"
+	if secretFolderUid == "" {
+		t.Skip("Skipping test - TF_ACC not set or test folder not configured")
+	}
+
+	configCreate := fmt.Sprintf(`
+		resource "secretsmanager_pam_user" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			login { value = "svcaccount" }
+
+			private_key_passphrase {
+				value = "s3cr3tpassphrase"
+			}
+
+			custom {
+				type  = "text"
+				label = "Team"
+				value = "backend"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	configUpdate := fmt.Sprintf(`
+		resource "secretsmanager_pam_user" "custom" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			login { value = "svcaccount" }
+
+			private_key_passphrase {
+				value = "s3cr3tpassphrase"
+			}
+
+			custom {
+				type  = "text"
+				label = "Team"
+				value = "platform"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: configCreate,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretExistsRemotely(secretUid),
+					resource.TestCheckResourceAttr("secretsmanager_pam_user.custom", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_user.custom", "custom.0.label", "Team"),
+					resource.TestCheckResourceAttr("secretsmanager_pam_user.custom", "custom.0.value", "backend"),
+					checkSecretResourceState("secretsmanager_pam_user.custom", func(s *terraform.InstanceState) error {
+						for k, v := range s.Attributes {
+							if v == "Private Key Passphrase" && k != "private_key_passphrase.0.type" {
+								return fmt.Errorf("passphrase label leaked into custom list at key %s", k)
+							}
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				Config: configUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("secretsmanager_pam_user.custom", "custom.0.value", "platform"),
+					checkSecretResourceState("secretsmanager_pam_user.custom", func(s *terraform.InstanceState) error {
+						passphrase := s.Attributes["private_key_passphrase.0.value"]
+						if passphrase == "" {
+							return fmt.Errorf("private_key_passphrase was wiped by custom field update")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/resource_passport.go
+++ b/secretsmanager/resource_passport.go
@@ -60,6 +60,8 @@ func resourcePassport() *schema.Resource {
 			"password":        schemaPasswordField(""),
 			"address_ref":     schemaAddressRefField(),
 			"file_ref":        schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -179,6 +181,14 @@ func resourcePassportCreate(ctx context.Context, d *schema.ResourceData, m inter
 		}
 	}
 
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
+		}
+	}
+
 	if folderUid == "*" {
 		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
 			return diag.FromErr(err)
@@ -292,6 +302,11 @@ func resourcePassportRead(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -365,6 +380,15 @@ func resourcePassportUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_photo.go
+++ b/secretsmanager/resource_photo.go
@@ -53,6 +53,8 @@ func resourcePhoto() *schema.Resource {
 			},
 			// fields[]
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -91,6 +93,14 @@ func resourcePhotoCreate(ctx context.Context, d *schema.ResourceData, m interfac
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -177,6 +187,11 @@ func resourcePhotoRead(ctx context.Context, d *schema.ResourceData, m interface{
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -214,6 +229,15 @@ func resourcePhotoUpdate(ctx context.Context, d *schema.ResourceData, m interfac
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_server_credentials.go
+++ b/secretsmanager/resource_server_credentials.go
@@ -56,6 +56,8 @@ func resourceServerCredentials() *schema.Resource {
 			"login":    schemaLoginField(),
 			"password": schemaPasswordField(""),
 			"file_ref": schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -132,6 +134,14 @@ func resourceServerCredentialsCreate(ctx context.Context, d *schema.ResourceData
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -232,6 +242,11 @@ func resourceServerCredentialsRead(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -285,6 +300,15 @@ func resourceServerCredentialsUpdate(ctx context.Context, d *schema.ResourceData
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_software_license.go
+++ b/secretsmanager/resource_software_license.go
@@ -56,6 +56,8 @@ func resourceSoftwareLicense() *schema.Resource {
 			"activation_date": schemaDateField(),
 			"expiration_date": schemaExpirationDateField(),
 			"file_ref":        schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -125,6 +127,14 @@ func resourceSoftwareLicenseCreate(ctx context.Context, d *schema.ResourceData, 
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -224,6 +234,11 @@ func resourceSoftwareLicenseRead(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -277,6 +292,15 @@ func resourceSoftwareLicenseUpdate(ctx context.Context, d *schema.ResourceData, 
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_ssh_keys.go
+++ b/secretsmanager/resource_ssh_keys.go
@@ -57,6 +57,8 @@ func resourceSshKeys() *schema.Resource {
 			"passphrase": schemaPasswordField("passphrase"),
 			"host":       schemaHostField(),
 			"file_ref":   schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -160,6 +162,14 @@ func resourceSshKeysCreate(ctx context.Context, d *schema.ResourceData, m interf
 		}
 	}
 
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
+		}
+	}
+
 	if folderUid == "*" {
 		if fuid, err := getTemplateFolder(folderUid, client); err != nil {
 			return diag.FromErr(err)
@@ -259,6 +269,11 @@ func resourceSshKeysRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	fileItems := getFileItemsResourceData(secret)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -368,6 +383,15 @@ func resourceSshKeysUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)

--- a/secretsmanager/resource_ssn_card.go
+++ b/secretsmanager/resource_ssn_card.go
@@ -55,6 +55,8 @@ func resourceSsnCard() *schema.Resource {
 			"identity_number": schemaAccountNumberField(),
 			"name":            schemaNameField(),
 			"file_ref":        schemaFileRefField(),
+			// custom[]
+			"custom": schemaCustomField(),
 		},
 	}
 }
@@ -114,6 +116,14 @@ func resourceSsnCardCreate(ctx context.Context, d *schema.ResourceData, m interf
 			if err := SetFieldTypeInSchema(d, "file_ref", "fileRef"); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if customData := d.Get("custom"); customData != nil {
+		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
+			return diag.FromErr(err)
+		} else {
+			nrc.Custom = fields
 		}
 	}
 
@@ -209,6 +219,11 @@ func resourceSsnCardRead(ctx context.Context, d *schema.ResourceData, m interfac
 		return diag.FromErr(err)
 	}
 
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
+		return diag.FromErr(err)
+	}
+
 	d.SetId(uid)
 	return diags
 }
@@ -257,6 +272,15 @@ func resourceSsnCardUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if _, err := ApplyFieldChange("fields", "file_ref", d, secret); err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	if d.HasChange("custom") {
+		customData := d.Get("custom").([]interface{})
+		fields, err := customFieldsFromSchema(customData)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		secret.RecordDict["custom"] = customFieldsToDict(fields)
 	}
 
 	secret.RawJson = core.DictToJson(secret.RecordDict)


### PR DESCRIPTION
## Summary

Implements user-defined custom fields (`custom` block) across all 22 resource types. Custom fields let users attach arbitrary typed data to any Keeper record from Terraform without schema changes — using a single `value` string for simple types and `jsonencode()` for complex structured types.

## Changes

### New Features

- **Custom fields on all 22 resources** (KSM-388): `login`, `bank_account`, `bank_card`, `birth_certificate`, `contact`, `database_credentials`, `driver_license`, `encrypted_notes`, `file`, `health_insurance`, `membership`, `passport`, `photo`, `server_credentials`, `software_license`, `ssh_keys`, `ssn_card`, `address`, `pam_database`, `pam_directory`, `pam_machine`, `pam_remote_browser`, `pam_user`
- **43+ Keeper field types supported**: simple types (`text`, `secret`, `url`, `email`, `multiline`, `checkbox`, `date`, `birthDate`, `expirationDate`) and structured types (`phone`, `name`, `address`, `paymentCard`, `bankAccount`, `host`, `securityQuestion`, `keyPair`, `script`). Unknown types fall through to plain string storage with no data loss.
- **Multi-value support**: structured types accept `jsonencode([{...},{...}])` for multiple entries in a single field
- **PAM merge logic** (`pam_machine`, `pam_user`): vault-managed "Private Key Passphrase" custom field is preserved across create/update — user-defined fields are merged around it, never overwriting it
- **`required` and `privacy_screen` round-trip**: `Computed: true` on both fields so imported records with these set don't produce perpetual diffs when HCL omits them

### Bug Fixes

- **Date timezone drift**: `date` custom fields now read back in UTC (was using local time, causing one-day drift for users in negative-offset timezones)
- **`birthDate` / `expirationDate`**: these date variants were falling through to plain text; now handled with the same millisecond → YYYY-MM-DD conversion as `date`
- **`checkbox` value type**: was stored as `[]string` (wrong); now correctly uses `core.Checkbox` with `[]bool`, matching all other SDKs
- **Reference type SDK structs**: `addressRef`, `cardRef`, `fileRef`, `oneTimeCode` were falling through to `core.Text`; now use their correct SDK struct types
- **`paymentCard` perpetual diff** (KSM-888, merged via #80): write path read snake_case keys (`card_number`, etc.) from the user's `jsonencode()` map, but SDK struct JSON tags are camelCase. Keys never matched — card always written empty, read back as `{}`, diffed on every plan. Fix: key lookups now use `cardNumber`, `cardExpirationDate`, `cardSecurityCode`.
- **Non-canonical `checkbox` and `date` inputs cause perpetual diffs** (KSM-889, merged via #81): `"yes"`/`"1"` for checkbox were silently coerced to `false`; RFC3339 for date fields was accepted on write but discarded to YYYY-MM-DD on read. Both caused perpetual diffs. Fix: strict validation — only `"true"`/`"false"` for checkbox, only YYYY-MM-DD for date types. Clear error returned for anything else.

### Docs / Examples

- Add `custom` block schema section to all 22 resource docs
- Create `pam_database.md` and `pam_directory.md` (resources existed without docs — pre-existing gap)
- Add `custom` block example to all 22 example `.tf` files

## Reviewer Guide

**XLARGE PR** (3,100+ lines, 83 files) — most of the size is mechanical repetition. Suggested review order:

### Review carefully (core logic — 2 files)

**`secretsmanager/provider.go`**
- `epochMsToDateUTC()` — extracted helper; see unit tests for the timezone edge case it guards
- `parseJSONItems()` — detects JSON array vs single object, enables multi-value fields
- `customFieldsFromSchema()` — full switch over all Keeper field types; each case constructs the correct SDK struct. Key things to review:
  - `checkbox` case: strict `"true"`/`"false"` validation with error (KSM-889)
  - `date`/`birthDate`/`expirationDate` case: YYYY-MM-DD only, no RFC3339 (KSM-889)
  - `paymentCard` case: camelCase key lookups (`cardNumber`, etc.) — KSM-888
- `getFieldItemsData()` — date type check extended to `birthDate`/`expirationDate`; calls `epochMsToDateUTC`

**`secretsmanager/record_fields.go`**
- `schemaCustomField()` — the TypeList schema for `custom`; `required` and `privacy_screen` have `Computed: true`

### Review the pattern, spot-check a few (22 resource files)

Each resource file has the same 4 additions: (1) `"custom": schemaCustomField()` in schema, (2) create block, (3) read via `getFieldItemsData`, (4) update via `customFieldsToDict` + `RawJson` sync.

Different from the pattern — review these individually:
- `resource_pam_machine.go` — merge logic: preserves "Private Key Passphrase" on update, filters it from read
- `resource_pam_user.go` — same merge logic

### Spot-check (tests, docs, examples)

- `secretsmanager/custom_fields_unit_test.go` — unit tests for `epochMsToDateUTC` (UTC timezone regression) and `parseJSONItems` (single object vs array); no vault required
- `secretsmanager/custom_fields_schema_test.go` — verifies `custom` TypeList with all 5 sub-keys is present in all 22 resource schemas; no vault required
- `secretsmanager/resource_login_custom_fields_test.go` — acceptance tests covering all major type categories, import/Computed regression, paymentCard round-trip (KSM-888), and ExpectError regression for checkbox/date non-canonical inputs (KSM-889)
- `resource_pam_machine_test.go`, `resource_pam_user_test.go` — merge logic tests

Estimated review time: 45–60 min (suggest 2 sessions: core logic first, resource files second)

## Breaking Changes

None. Custom fields are additive — existing configs require no changes.

Notes on corrected behavior (not breaking, since these inputs were already producing wrong results):
- `paymentCard`: use camelCase keys in `jsonencode()` — snake_case keys never worked (perpetual diff)
- `checkbox`: use `"true"` or `"false"` — other values now error instead of silently storing `false`
- `date`/`birthDate`/`expirationDate`: use YYYY-MM-DD — RFC3339 now errors instead of silently causing a perpetual diff

## Related Issues

- Closes #16 (custom field support — opened 2023-03-13)
- Jira: KSM-388
- Jira: KSM-888 (paymentCard key fix, merged via #80)
- Jira: KSM-889 (checkbox/date non-canonical input rejection, merged via #81)