### PR TITLE
KSM-885: document Alpine Linux compatibility for all Linux binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,5 +49,11 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  footer: |
+    ## Platform Compatibility
+
+    All Linux binaries are statically compiled (`CGO_ENABLED=0`) and have no C library dependencies.
+    The `linux_amd64`, `linux_arm64`, and `linux_arm` builds run on Alpine Linux and other musl-based
+    systems without modification — no special version required.
 # If you want to manually examine the release before its live, uncomment this line:
 # draft: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0]
 
+### Security
+- Bump `cloudflare/circl` to v1.6.3 and `grpc` to v1.79.3 to address known vulnerabilities
+
 ### Added
+- Document Alpine Linux and musl-based container compatibility — all Linux binaries are statically compiled (`CGO_ENABLED=0`) with no C library dependencies and run on Alpine and other musl-based systems without modification (KSM-885)
+
 - **Ephemeral Resources** (KSM-871):
   - Add ephemeral resource support for Terraform 1.10+, ensuring secrets are never stored in `terraform.tfstate`
   - Ephemeral resources available for all 25 record types: `login`, `field`, `record`, `database_credentials`, `server_credentials`, `ssh_keys`, `encrypted_notes`, `address`, `bank_account`, `bank_card`, `birth_certificate`, `contact`, `driver_license`, `health_insurance`, `membership`, `passport`, `photo`, `software_license`, `ssn_card`, `file`, `pam_user`, `pam_machine`, `pam_database`, `pam_directory`, `pam_remote_browser`
@@ -25,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full CRUD lifecycle with import support
 
 ### Fixed
+- Fix wrong JSON key in `pamHostnameToListValue` causing incorrect PAM hostname field mapping (KSM-884)
 - Remove invalid `DiffSuppressFunc` and `ValidateFunc` from computed-only `pam_remote_browser_settings` field in the `pam_remote_browser` data source
 - Add nil-check guard in all ephemeral resource `Open()` methods to prevent panics if provider configuration is missing
 - Surface warning diagnostics when referenced `addressRef` or `cardRef` records cannot be fetched, instead of silently returning empty fields

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ curl -SfLOJ https://github.com/keeper-security/terraform-provider-secretsmanager
 ```
 Have a look at some working [examples](./examples) in this repo.
 
+### Alpine Linux and Container Compatibility
+
+All Linux binaries are compiled with `CGO_ENABLED=0`, producing a fully static binary with no C library dependencies. The `linux_amd64`, `linux_arm64`, and `linux_arm` builds run on any Linux distribution — including Alpine Linux and other musl-based container images — without modification.
+
+No special installation steps or alternative binaries are required for Alpine.
+
 ### Terraform v0.12 and below
 Manually install the Keeper Secrets Manager provider by downloading the corresponding archive for your platform then extract the executable and move it to `~/.terraform/plugins` or `%APPDATA%\terraform.d\plugins` on Windows.
 


### PR DESCRIPTION
## Summary

- Add explicit Alpine Linux / musl compatibility documentation to README
- Add `Platform Compatibility` footer to `.goreleaser.yml` so it appears on every GitHub release page
- Backfill CHANGELOG `[1.3.0]` with two missing entries: KSM-884 bug fix and security dependency bumps

## Changes

**Documentation**
- `README.md`: new "Alpine Linux and Container Compatibility" subsection under manual install instructions
- `.goreleaser.yml`: `release.footer` block appended to every release description on GitHub

**Changelog**
- `CHANGELOG.md`: add `Security` section (circl + grpc bumps) and KSM-884 fix entry to `[1.3.0]`; Alpine note added under `Added`

## Background

All Linux binaries are compiled with `CGO_ENABLED=0`, producing a fully static binary with no C library dependencies. Confirmed by running the `v1.2.0` `linux_amd64` binary in both `ubuntu:latest` and `alpine:latest` Docker containers (`--platform linux/amd64`); `readelf -d` confirmed no dynamic section. Terraform protocol v5/v6 has no opinion on C library — both sides are statically linked.

No new build targets or code changes are required.

## Related Issues

Closes KSM-885