### PR TITLE
KSM-888: fix paymentCard key names to match SDK JSON tags

### DIFF
--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -496,9 +496,9 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for paymentCard entry: %w", label, err)
 					}
 					card := core.PaymentCard{}
-					if s, ok := v["card_number"].(string); ok { card.CardNumber = s }
-					if s, ok := v["card_expiration_date"].(string); ok { card.CardExpirationDate = s }
-					if s, ok := v["card_security_code"].(string); ok { card.CardSecurityCode = s }
+					if s, ok := v["cardNumber"].(string); ok { card.CardNumber = s }
+					if s, ok := v["cardExpirationDate"].(string); ok { card.CardExpirationDate = s }
+					if s, ok := v["cardSecurityCode"].(string); ok { card.CardSecurityCode = s }
 					f.Value = append(f.Value, card)
 				}
 			}

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -525,14 +525,22 @@ func TestAccResourceLogin_customFieldAddress(t *testing.T) {
 	})
 }
 
-// TestAccResourceLogin_customFieldPaymentCard tests the paymentCard complex type.
-func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
+// TestAccResourceLogin_customFieldPaymentCardRoundTrip is the regression test for KSM-888:
+// paymentCard keys must use camelCase (cardNumber, cardExpirationDate, cardSecurityCode)
+// to match what the read path serializes via toJsonDefault() / json.Marshal on the SDK
+// struct. The original write path read snake_case keys (card_number, card_expiration_date,
+// card_security_code), which never matched any real key in the user's jsonencode output,
+// causing the card to be written empty and a perpetual plan diff on every apply.
+//
+// Failure mode before fix: PlanOnly step detects diff (state "{}"; config has card data).
+// Passing mode after fix: both write and read use camelCase; round-trip is stable.
+func TestAccResourceLogin_customFieldPaymentCardRoundTrip(t *testing.T) {
 	secretFolderUid := testAcc.getTestFolder()
 	secretUid := core.GenerateUid()
-	secretTitle := "tf_acc_custom_payment_card"
+	secretTitle := "tf_acc_custom_payment_card_rt"
 
 	config := fmt.Sprintf(`
-		resource "secretsmanager_login" "custom_payment_card" {
+		resource "secretsmanager_login" "custom_payment_card_rt" {
 			folder_uid = "%v"
 			uid        = "%v"
 			title      = "%v"
@@ -541,9 +549,9 @@ func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
 				type  = "paymentCard"
 				label = "Corporate Card"
 				value = jsonencode({
-					card_number          = "4111111111111111"
-					card_expiration_date = "12/2027"
-					card_security_code   = "123"
+					cardNumber         = "4111111111111111"
+					cardExpirationDate = "12/2027"
+					cardSecurityCode   = "123"
 				})
 			}
 		}
@@ -557,13 +565,16 @@ func TestAccResourceLogin_customFieldPaymentCard(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					checkSecretExistsRemotely(secretUid),
-					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.#", "1"),
-					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.0.type", "paymentCard"),
-					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card", "custom.0.label", "Corporate Card"),
-					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_payment_card", "custom.0.value"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card_rt", "custom.#", "1"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card_rt", "custom.0.type", "paymentCard"),
+					resource.TestCheckResourceAttr("secretsmanager_login.custom_payment_card_rt", "custom.0.label", "Corporate Card"),
+					resource.TestCheckResourceAttrSet("secretsmanager_login.custom_payment_card_rt", "custom.0.value"),
 				),
 			},
 			{
+				// Regression guard: state must equal config — no perpetual diff.
+				// Before fix: write path read card_number (snake_case, not found) →
+				// wrote empty card → read back "{}" → diff on every plan.
 				Config:   config,
 				PlanOnly: true,
 			},


### PR DESCRIPTION
## What

Fixes a perpetual plan diff on `paymentCard` custom fields.

The `customFieldsFromSchema()` write path read snake_case keys from the user's `jsonencode()` map — `card_number`, `card_expiration_date`, `card_security_code` — but the SDK struct JSON tags are camelCase: `cardNumber`, `cardExpirationDate`, `cardSecurityCode`.

Since `jsonencode` preserves the user's key names exactly, the snake_case lookups never matched anything. Every paymentCard custom field was silently written as an empty struct, and the read path serialized it back as `{}`. This caused a perpetual diff on every subsequent plan.

## Fix

Three-line change in the `paymentCard` case of `customFieldsFromSchema()` in `provider.go`:

```
- if s, ok := v["card_number"].(string); ok { card.CardNumber = s }
- if s, ok := v["card_expiration_date"].(string); ok { card.CardExpirationDate = s }
- if s, ok := v["card_security_code"].(string); ok { card.CardSecurityCode = s }
+ if s, ok := v["cardNumber"].(string); ok { card.CardNumber = s }
+ if s, ok := v["cardExpirationDate"].(string); ok { card.CardExpirationDate = s }
+ if s, ok := v["cardSecurityCode"].(string); ok { card.CardSecurityCode = s }
```

The camelCase keys now match the JSON the read path produces via `toJsonDefault()`/`json.Marshal` on `core.PaymentCard`, making the round-trip consistent.

## User-facing change

Users should write paymentCard values with camelCase keys (matching what the Keeper API uses):

```hcl
custom {
  type  = "paymentCard"
  label = "Corporate Card"
  value = jsonencode({
    cardNumber         = "4111111111111111"
    cardExpirationDate = "12/2027"
    cardSecurityCode   = "123"
  })
}
```

## Test

Added `TestAccResourceLogin_customFieldPaymentCardRoundTrip` — regression guard with a `PlanOnly` step that would fail before this fix (state `{}` vs config with card data) and passes after.

Unit suite (no vault required):

```bash
go test ./secretsmanager -run "TestEpochMsToDateUTC|TestParseJSONItems|TestCustomFieldSchemaPresence" -v
# PASS (9/9)
```

## Related

Closes KSM-888. Targets `KSM-388-custom-fields` (will ship as part of v1.3.0 via PR #77).