### PR TITLE
KSM-889: reject non-canonical checkbox and date values with clear errors

### DIFF
--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -397,22 +397,22 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 		case "checkbox":
 			f := &core.Checkbox{KeeperRecordField: base, Required: required}
 			if value != "" {
-				f.Value = []bool{strings.ToLower(value) == "true"}
+				lower := strings.ToLower(value)
+				if lower != "true" && lower != "false" {
+					return nil, fmt.Errorf("custom field %q: invalid checkbox value %q — use \"true\" or \"false\"", label, value)
+				}
+				f.Value = []bool{lower == "true"}
 			}
 			fields = append(fields, f)
 
 		case "date", "birthDate", "expirationDate":
 			f := &core.Date{KeeperRecordField: base, Required: required, PrivacyScreen: privacyScreen}
 			if value != "" {
-				t, err := time.Parse(time.RFC3339, value)
+				t, err := time.Parse("2006-01-02", value)
 				if err != nil {
-					// fall back to date-only format
-					t, err = time.Parse("2006-01-02", value)
-					if err != nil {
-						return nil, fmt.Errorf("custom field %q: invalid date value %q — use RFC3339 or YYYY-MM-DD", label, value)
-					}
+					return nil, fmt.Errorf("custom field %q: invalid date value %q — use YYYY-MM-DD format (e.g. \"2026-03-20\")", label, value)
 				}
-				f.Value = []int64{t.UnixMilli()}
+				f.Value = []int64{t.UTC().UnixMilli()}
 			}
 			fields = append(fields, f)
 

--- a/secretsmanager/resource_login_custom_fields_test.go
+++ b/secretsmanager/resource_login_custom_fields_test.go
@@ -3,6 +3,7 @@ package secretsmanager
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -583,7 +584,7 @@ func TestAccResourceLogin_customFieldPaymentCardRoundTrip(t *testing.T) {
 }
 
 // TestAccResourceLogin_customFieldDate tests a date custom field using YYYY-MM-DD format.
-// RFC3339 is also accepted on write but the read path always returns YYYY-MM-DD.
+// Only YYYY-MM-DD is accepted — RFC3339 is rejected with a clear error (KSM-889).
 func TestAccResourceLogin_customFieldDate(t *testing.T) {
 	secretFolderUid := testAcc.getTestFolder()
 	secretUid := core.GenerateUid()
@@ -763,6 +764,86 @@ func TestAccResourceLogin_customFieldKeyPair(t *testing.T) {
 			{
 				Config:   config,
 				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldCheckboxInvalidInput is the regression test for KSM-889
+// (checkbox). Values like "yes", "1", "on" were silently treated as false — because
+// strings.ToLower(value) == "true" is false for them — then read back as "false", causing
+// a perpetual diff between config and state.
+//
+// After KSM-889: apply returns an error immediately, directing the user to use "true" or "false".
+// Failure mode before fix: no error raised → ExpectError step fails (expected error, got none).
+// Passing mode after fix: error raised → ExpectError step passes.
+func TestAccResourceLogin_customFieldCheckboxInvalidInput(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_checkbox_invalid"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_checkbox_invalid" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "checkbox"
+				label = "Feature"
+				value = "yes"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`invalid checkbox value`),
+			},
+		},
+	})
+}
+
+// TestAccResourceLogin_customFieldDateInvalidFormat is the regression test for KSM-889
+// (date). RFC3339 values like "2026-03-20T14:30:00Z" were silently accepted, stored as
+// epoch ms, but the read path always returned "2026-03-20" (YYYY-MM-DD only, time
+// component discarded). This caused a perpetual diff: config kept the RFC3339 string
+// while state showed YYYY-MM-DD.
+//
+// After KSM-889: apply returns an error immediately, directing the user to use YYYY-MM-DD.
+// Applies equally to date, birthDate, and expirationDate — all share the same write path.
+// Failure mode before fix: no error raised → ExpectError step fails (expected error, got none).
+// Passing mode after fix: error raised → ExpectError step passes.
+func TestAccResourceLogin_customFieldDateInvalidFormat(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_custom_date_invalid"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_date_invalid" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "date"
+				label = "Review"
+				value = "2026-03-20T14:30:00Z"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`invalid date value`),
 			},
 		},
 	})


### PR DESCRIPTION
## What

Fixes perpetual plan diffs caused by two custom field types silently accepting non-canonical input formats.

### checkbox

Values like `"yes"`, `"1"`, `"on"` were silently treated as `false` — `strings.ToLower(value) == "true"` is false for all of them. The vault stored `false`, the read path returned `"false"`, but the config retained `"yes"`. Perpetual diff.

**Fix**: strict `"true"`/`"false"` validation (case-insensitive). Any other value returns a clear error:
```
custom field "Feature": invalid checkbox value "yes" — use "true" or "false"
```

### date / birthDate / expirationDate

RFC3339 input (`"2026-03-20T14:30:00Z"`) was silently accepted on write, stored as epoch ms, but the read path always returned `"2026-03-20"` (YYYY-MM-DD only, time component discarded). Config kept RFC3339 while state showed YYYY-MM-DD. Perpetual diff.

**Fix**: only YYYY-MM-DD is accepted. RFC3339 now returns a clear error:
```
custom field "Review": invalid date value "2026-03-20T14:30:00Z" — use YYYY-MM-DD format (e.g. "2026-03-20")
```

## Changes

Two targeted edits in `customFieldsFromSchema()` in `provider.go`:

**checkbox** (was 1 line, now 4):
```go
// Before:
f.Value = []bool{strings.ToLower(value) == "true"}

// After:
lower := strings.ToLower(value)
if lower != "true" && lower != "false" {
    return nil, fmt.Errorf("custom field %q: invalid checkbox value %q — use \"true\" or \"false\"", label, value)
}
f.Value = []bool{lower == "true"}
```

**date** (simplified from try-RFC3339-fallback to YYYY-MM-DD-only):
```go
// Before: tried RFC3339 first, fell back to YYYY-MM-DD
// After:
t, err := time.Parse("2006-01-02", value)
if err != nil {
    return nil, fmt.Errorf("custom field %q: invalid date value %q — use YYYY-MM-DD format (e.g. \"2026-03-20\")", label, value)
}
f.Value = []int64{t.UTC().UnixMilli()}
```

## Tests

Two `ExpectError` regression tests added to `resource_login_custom_fields_test.go`:
- `TestAccResourceLogin_customFieldCheckboxInvalidInput` — `"yes"` → expects error; fails before fix (no error raised), passes after
- `TestAccResourceLogin_customFieldDateInvalidFormat` — RFC3339 → expects error; fails before fix (no error raised), passes after

Existing tests that must still pass (canonical formats unchanged):
- `TestAccResourceLogin_customFieldCheckbox` — uses `"true"` ✓
- `TestAccResourceLogin_customFieldDate` — uses `"2025-06-01"` ✓
- `TestAccResourceLogin_customFieldBirthDate` — uses YYYY-MM-DD ✓

Unit suite (no vault):
```
go test ./secretsmanager -run "TestEpochMsToDateUTC|TestParseJSONItems|TestCustomFieldSchemaPresence" -v
# PASS (9/9)
```

## Breaking Changes

Users who were passing RFC3339 to date fields or `"yes"`/`"1"` to checkbox fields will now get an error. In both cases they were already experiencing a perpetual diff — the error replaces a silent failure with a clear message.

## Related

Closes KSM-889. Targets `KSM-388-custom-fields` (ships as part of v1.3.0 via PR #77).