### PR TITLE
KSM-907: Validate reserved custom field labels on PAM resources

### DIFF
--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -673,6 +673,31 @@ func customFieldsToDict(fields []interface{}) []interface{} {
 	return result
 }
 
+// pamReservedCustomLabels contains labels that pam_machine and pam_user inject
+// as platform-managed custom fields. User config must not reuse these labels.
+var pamReservedCustomLabels = map[string]bool{
+	"Private Key Passphrase": true,
+}
+
+// validatePamCustomFieldLabels returns an error if any item in a custom field
+// schema list uses a platform-reserved label.
+func validatePamCustomFieldLabels(items []interface{}, resourceType string) error {
+	for _, raw := range items {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		label, _ := m["label"].(string)
+		if pamReservedCustomLabels[label] {
+			return fmt.Errorf(
+				"custom field label %q is reserved for platform use on %s and cannot be used for user-defined custom fields",
+				label, resourceType,
+			)
+		}
+	}
+	return nil
+}
+
 func getTotpCode(totpUrl string) (code string, seconds int, err error) {
 	if totp, err := core.GetTotpCode(totpUrl); err == nil {
 		return totp.Code, totp.TimeLeft, nil

--- a/secretsmanager/resource_pam_machine.go
+++ b/secretsmanager/resource_pam_machine.go
@@ -301,6 +301,9 @@ func resourcePamMachineCreate(ctx context.Context, d *schema.ResourceData, m int
 	// User-defined custom fields — appended after the platform-managed
 	// "Private Key Passphrase" entry already placed in nrc.Custom above.
 	if customData := d.Get("custom"); customData != nil {
+		if err := validatePamCustomFieldLabels(customData.([]interface{}), "pam_machine"); err != nil {
+			return diag.FromErr(err)
+		}
 		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
 			return diag.FromErr(err)
 		} else {
@@ -655,6 +658,9 @@ func resourcePamMachineUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 	if d.HasChange("custom") {
 		customData := d.Get("custom").([]interface{})
+		if err := validatePamCustomFieldLabels(customData, "pam_machine"); err != nil {
+			return diag.FromErr(err)
+		}
 		userFields, err := customFieldsFromSchema(customData)
 		if err != nil {
 			return diag.FromErr(err)

--- a/secretsmanager/resource_pam_machine_test.go
+++ b/secretsmanager/resource_pam_machine_test.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -487,6 +488,35 @@ func TestAccResourcePamMachine_generatePrivatePemKeyWithPassphrase(t *testing.T)
 						return nil
 					}),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePamMachine_customFieldReservedLabel(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_machine" "reserved_label" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "test-reserved-label"
+			custom {
+				type  = "secret"
+				label = "Private Key Passphrase"
+				value = "user-value"
+			}
+		}
+	`, secretFolderUid, secretUid)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Private Key Passphrase`),
 			},
 		},
 	})

--- a/secretsmanager/resource_pam_user.go
+++ b/secretsmanager/resource_pam_user.go
@@ -248,6 +248,9 @@ func resourcePamUserCreate(ctx context.Context, d *schema.ResourceData, m interf
 	// User-defined custom fields — appended after the platform-managed
 	// "Private Key Passphrase" entry already placed in nrc.Custom above.
 	if customData := d.Get("custom"); customData != nil {
+		if err := validatePamCustomFieldLabels(customData.([]interface{}), "pam_user"); err != nil {
+			return diag.FromErr(err)
+		}
 		if fields, err := customFieldsFromSchema(customData.([]interface{})); err != nil {
 			return diag.FromErr(err)
 		} else {
@@ -526,6 +529,9 @@ func resourcePamUserUpdate(ctx context.Context, d *schema.ResourceData, m interf
 
 	if d.HasChange("custom") {
 		customData := d.Get("custom").([]interface{})
+		if err := validatePamCustomFieldLabels(customData, "pam_user"); err != nil {
+			return diag.FromErr(err)
+		}
 		userFields, err := customFieldsFromSchema(customData)
 		if err != nil {
 			return diag.FromErr(err)

--- a/secretsmanager/resource_pam_user_test.go
+++ b/secretsmanager/resource_pam_user_test.go
@@ -2,6 +2,7 @@ package secretsmanager
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -428,6 +429,35 @@ func TestAccResourcePamUser_customField(t *testing.T) {
 						return nil
 					}),
 				),
+			},
+		},
+	})
+}
+
+func TestAccResourcePamUser_customFieldReservedLabel(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_pam_user" "reserved_label" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "test-reserved-label"
+			custom {
+				type  = "secret"
+				label = "Private Key Passphrase"
+				value = "user-value"
+			}
+		}
+	`, secretFolderUid, secretUid)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`Private Key Passphrase`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Fixes a critical bug where PAM resources (`pam_machine`, `pam_user`) allowed users to define custom fields with platform-reserved labels, causing silent duplicates in the vault, perpetual Terraform diffs, and resources becoming permanently unmanageable (panic on any operation).

The fix adds validation in the Create and Update paths to reject user-defined custom fields with reserved labels before any vault operation, producing a clear diagnostic error.

## What Changed

- Added `pamReservedCustomLabels` map and `validatePamCustomFieldLabels()` helper in `provider.go`
- Integrated validation in both Create and Update paths for `pam_machine` and `pam_user`
- Added regression tests verifying the error is raised for reserved labels

## Evidence

- ✅ New validation tests pass (error correctly raised for reserved labels)
- ✅ All 18 existing PAM acceptance tests pass (no regressions)
- ✅ Code builds without errors

## Fixes

Closes KSM-907