### PR TITLE
KSM-907: case-insensitive reserved label validation

### DIFF
--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -680,7 +680,7 @@ var pamReservedCustomLabels = map[string]bool{
 }
 
 // validatePamCustomFieldLabels returns an error if any item in a custom field
-// schema list uses a platform-reserved label.
+// schema list uses a platform-reserved label (case-insensitive comparison).
 func validatePamCustomFieldLabels(items []interface{}, resourceType string) error {
 	for _, raw := range items {
 		m, ok := raw.(map[string]interface{})
@@ -688,11 +688,13 @@ func validatePamCustomFieldLabels(items []interface{}, resourceType string) erro
 			continue
 		}
 		label, _ := m["label"].(string)
-		if pamReservedCustomLabels[label] {
-			return fmt.Errorf(
-				"custom field label %q is reserved for platform use on %s and cannot be used for user-defined custom fields",
-				label, resourceType,
-			)
+		for reserved := range pamReservedCustomLabels {
+			if strings.EqualFold(label, reserved) {
+				return fmt.Errorf(
+					"custom field label %q is reserved for platform use on %s and cannot be used for user-defined custom fields",
+					label, resourceType,
+				)
+			}
 		}
 	}
 	return nil

--- a/secretsmanager/provider_test.go
+++ b/secretsmanager/provider_test.go
@@ -154,6 +154,29 @@ func TestProvider(t *testing.T) {
 	}
 }
 
+func TestValidatePamCustomFieldLabels(t *testing.T) {
+	cases := []struct {
+		label   string
+		wantErr bool
+	}{
+		{"Private Key Passphrase", true},  // exact canonical — blocked
+		{"private key passphrase", true},  // all lowercase — now blocked
+		{"PRIVATE KEY PASSPHRASE", true},  // all uppercase — now blocked
+		{"Private Key PASSPHRASE", true},  // mixed case — now blocked
+		{"Owner", false},                  // non-reserved — allowed
+		{"", false},                       // empty — allowed
+	}
+	for _, tc := range cases {
+		items := []interface{}{
+			map[string]interface{}{"label": tc.label, "type": "secret", "value": []interface{}{"x"}},
+		}
+		err := validatePamCustomFieldLabels(items, "secretsmanager_pam_machine")
+		if (err != nil) != tc.wantErr {
+			t.Errorf("label=%q: wantErr=%v got err=%v", tc.label, tc.wantErr, err)
+		}
+	}
+}
+
 func checkSecretExistsRemotely(uid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccClient()

--- a/secretsmanager/resource_pam_machine.go
+++ b/secretsmanager/resource_pam_machine.go
@@ -469,7 +469,7 @@ func resourcePamMachineRead(ctx context.Context, d *schema.ResourceData, m inter
 	userCustom := make([]interface{}, 0, len(allCustom))
 	for _, item := range allCustom {
 		if m, ok := item.(map[string]interface{}); ok {
-			if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+			if label, _ := m["label"].(string); strings.EqualFold(label, "Private Key Passphrase") {
 				continue
 			}
 		}
@@ -671,7 +671,7 @@ func resourcePamMachineUpdate(ctx context.Context, d *schema.ResourceData, m int
 		if current, ok := secret.RecordDict["custom"].([]interface{}); ok {
 			for _, item := range current {
 				if m, ok := item.(map[string]interface{}); ok {
-					if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+					if label, _ := m["label"].(string); strings.EqualFold(label, "Private Key Passphrase") {
 						preserved = append(preserved, item)
 					}
 				}

--- a/secretsmanager/resource_pam_user.go
+++ b/secretsmanager/resource_pam_user.go
@@ -392,7 +392,7 @@ func resourcePamUserRead(ctx context.Context, d *schema.ResourceData, m interfac
 	userCustom := make([]interface{}, 0, len(allCustom))
 	for _, item := range allCustom {
 		if m, ok := item.(map[string]interface{}); ok {
-			if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+			if label, _ := m["label"].(string); strings.EqualFold(label, "Private Key Passphrase") {
 				continue
 			}
 		}
@@ -542,7 +542,7 @@ func resourcePamUserUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		if current, ok := secret.RecordDict["custom"].([]interface{}); ok {
 			for _, item := range current {
 				if m, ok := item.(map[string]interface{}); ok {
-					if label, _ := m["label"].(string); label == "Private Key Passphrase" {
+					if label, _ := m["label"].(string); strings.EqualFold(label, "Private Key Passphrase") {
 						preserved = append(preserved, item)
 					}
 				}


### PR DESCRIPTION
## Summary

Defense-in-depth fix for KSM-907: switch all 'Private Key Passphrase' reserved label checks to case-insensitive comparison using strings.EqualFold.

QA found that lowercase variants like "private key passphrase" bypass the validation due to case-sensitive string comparisons. While this doesn't reproduce the original crash (since the Read-path filter is also case-sensitive), it closes a validation gap.

## Changes

**provider.go** (validatePamCustomFieldLabels):
- Replaced pamReservedCustomLabels[label] (exact map lookup) with strings.EqualFold loop

**resource_pam_machine.go**:
- Line 472 (Read filter): label == "Private Key Passphrase" → strings.EqualFold(label, "Private Key Passphrase")
- Line 674 (Update preserve loop): Same change

**resource_pam_user.go**:
- Line 395 (Read filter): Same strings.EqualFold change
- Line 545 (Update preserve loop): Same change

**provider_test.go**:
- Add unit test TestValidatePamCustomFieldLabels covering exact, lowercase, uppercase, and mixed-case variants

## Related Issues

- Addresses Jira comment: KSM-907 comment 331522
- Fixes regression: case-variant labels bypass reserved-label validation