### PR TITLE
KSM-910: expose custom fields in data sources and ephemeral resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Document Alpine Linux and musl-based container compatibility — all Linux binaries are statically compiled (`CGO_ENABLED=0`) with no C library dependencies and run on Alpine and other musl-based systems without modification (KSM-885)
 
+- **Custom fields in data sources and ephemeral resources** (KSM-910):
+  - Expose the `custom` block on all 20 record-type data sources (`data "secretsmanager_<type>"`) — allows reading custom field values from existing vault records
+  - Expose the `custom` block on all 20 record-type ephemeral resources (`ephemeral "secretsmanager_<type>"`) — custom field values are returned without being stored in state
+  - Each `custom` entry is a read-only block with `type`, `label`, `value`, `required`, and `privacy_screen` attributes
+  - Completes KSM-388 custom field support across all three resource layers: managed resources (write), data sources (read), and ephemeral resources (read, no state)
+
 - **Ephemeral Resources** (KSM-871):
   - Add ephemeral resource support for Terraform 1.10+, ensuring secrets are never stored in `terraform.tfstate`
   - Ephemeral resources available for all 25 record types: `login`, `field`, `record`, `database_credentials`, `server_credentials`, `ssh_keys`, `encrypted_notes`, `address`, `bank_account`, `bank_card`, `birth_certificate`, `contact`, `driver_license`, `health_insurance`, `membership`, `passport`, `photo`, `software_license`, `ssn_card`, `file`, `pam_user`, `pam_machine`, `pam_database`, `pam_directory`, `pam_remote_browser`

--- a/secretsmanager/custom_fields_data_source_schema_test.go
+++ b/secretsmanager/custom_fields_data_source_schema_test.go
@@ -1,0 +1,117 @@
+package secretsmanager
+
+import (
+	"context"
+	"testing"
+
+	fwephemeral "github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestCustomFieldDataSourceSchemaPresence verifies that every record-type data
+// source schema contains the "custom" TypeList key with the expected 5
+// sub-attributes. No vault required.
+func TestCustomFieldDataSourceSchemaPresence(t *testing.T) {
+	dataSources := map[string]*schema.Resource{
+		"address":              dataSourceAddress(),
+		"bank_account":         dataSourceBankAccount(),
+		"bank_card":            dataSourceBankCard(),
+		"birth_certificate":    dataSourceBirthCertificate(),
+		"contact":              dataSourceContact(),
+		"database_credentials": dataSourceDatabaseCredentials(),
+		"driver_license":       dataSourceDriverLicense(),
+		"encrypted_notes":      dataSourceEncryptedNotes(),
+		"health_insurance":     dataSourceHealthInsurance(),
+		"login":                dataSourceLogin(),
+		"membership":           dataSourceMembership(),
+		"pam_database":         dataSourcePamDatabase(),
+		"pam_directory":        dataSourcePamDirectory(),
+		"pam_remote_browser":   dataSourcePamRemoteBrowser(),
+		"passport":             dataSourcePassport(),
+		"photo":                dataSourcePhoto(),
+		"server_credentials":   dataSourceServerCredentials(),
+		"software_license":     dataSourceSoftwareLicense(),
+		"ssh_keys":             dataSourceSshKeys(),
+		"ssn_card":             dataSourceSsnCard(),
+	}
+
+	requiredSubKeys := []string{"type", "label", "value", "required", "privacy_screen"}
+
+	for name, res := range dataSources {
+		t.Run(name, func(t *testing.T) {
+			customSchema, ok := res.Schema["custom"]
+			if !ok {
+				t.Fatalf("data source %q: \"custom\" key missing from schema", name)
+			}
+			if customSchema.Type != schema.TypeList {
+				t.Errorf("data source %q: \"custom\" is %v, want TypeList", name, customSchema.Type)
+			}
+			if !customSchema.Computed {
+				t.Errorf("data source %q: \"custom\" must be Computed (read-only)", name)
+			}
+			elem, ok := customSchema.Elem.(*schema.Resource)
+			if !ok {
+				t.Fatalf("data source %q: \"custom\" Elem is not *schema.Resource", name)
+			}
+			for _, key := range requiredSubKeys {
+				sub, found := elem.Schema[key]
+				if !found {
+					t.Errorf("data source %q: \"custom\" block missing sub-key %q", name, key)
+					continue
+				}
+				if !sub.Computed {
+					t.Errorf("data source %q: \"custom.%s\" must be Computed", name, key)
+				}
+			}
+		})
+	}
+}
+
+// ephemeralSchemaProvider is the subset of the Plugin Framework ephemeral
+// resource interface that exposes the schema.
+type ephemeralSchemaProvider interface {
+	Schema(context.Context, fwephemeral.SchemaRequest, *fwephemeral.SchemaResponse)
+}
+
+// TestCustomFieldEphemeralSchemaPresence verifies that every record-type
+// ephemeral resource schema contains the "custom" attribute. No vault required.
+func TestCustomFieldEphemeralSchemaPresence(t *testing.T) {
+	ephemeralResources := map[string]fwephemeral.EphemeralResource{
+		"address":              NewEphemeralAddress(),
+		"bank_account":         NewEphemeralBankAccount(),
+		"bank_card":            NewEphemeralBankCard(),
+		"birth_certificate":    NewEphemeralBirthCertificate(),
+		"contact":              NewEphemeralContact(),
+		"database_credentials": NewEphemeralDatabaseCredentials(),
+		"driver_license":       NewEphemeralDriverLicense(),
+		"encrypted_notes":      NewEphemeralEncryptedNotes(),
+		"health_insurance":     NewEphemeralHealthInsurance(),
+		"login":                NewEphemeralLogin(),
+		"membership":           NewEphemeralMembership(),
+		"pam_database":         NewEphemeralPamDatabase(),
+		"pam_directory":        NewEphemeralPamDirectory(),
+		"pam_machine":          NewEphemeralPamMachine(),
+		"pam_remote_browser":   NewEphemeralPamRemoteBrowser(),
+		"pam_user":             NewEphemeralPamUser(),
+		"passport":             NewEphemeralPassport(),
+		"photo":                NewEphemeralPhoto(),
+		"server_credentials":   NewEphemeralServerCredentials(),
+		"software_license":     NewEphemeralSoftwareLicense(),
+		"ssh_keys":             NewEphemeralSshKeys(),
+		"ssn_card":             NewEphemeralSsnCard(),
+	}
+
+	for name, res := range ephemeralResources {
+		t.Run(name, func(t *testing.T) {
+			sp, ok := res.(ephemeralSchemaProvider)
+			if !ok {
+				t.Fatalf("ephemeral %q: does not implement Schema()", name)
+			}
+			var resp fwephemeral.SchemaResponse
+			sp.Schema(context.Background(), fwephemeral.SchemaRequest{}, &resp)
+			if _, found := resp.Schema.Attributes["custom"]; !found {
+				t.Fatalf("ephemeral %q: \"custom\" attribute missing from schema", name)
+			}
+		})
+	}
+}

--- a/secretsmanager/data_source_address.go
+++ b/secretsmanager/data_source_address.go
@@ -117,6 +117,7 @@ func dataSourceAddress() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -155,6 +156,11 @@ func dataSourceAddressRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	fileItems := getFileItemsData(secret.Files)
 	if err = d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_bank_account.go
+++ b/secretsmanager/data_source_bank_account.go
@@ -225,6 +225,7 @@ func dataSourceBankAccount() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -309,6 +310,11 @@ func dataSourceBankAccountRead(ctx context.Context, d *schema.ResourceData, m in
 		}
 	}
 	if err = d.Set("totp", totpItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_bank_card.go
+++ b/secretsmanager/data_source_bank_card.go
@@ -159,6 +159,7 @@ func dataSourceBankCard() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -217,6 +218,11 @@ func dataSourceBankCardRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_birth_certificate.go
+++ b/secretsmanager/data_source_birth_certificate.go
@@ -109,6 +109,7 @@ func dataSourceBirthCertificate() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -156,6 +157,11 @@ func dataSourceBirthCertificateRead(ctx context.Context, d *schema.ResourceData,
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_contact.go
+++ b/secretsmanager/data_source_contact.go
@@ -185,6 +185,7 @@ func dataSourceContact() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -247,6 +248,11 @@ func dataSourceContactRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_database_credentials.go
+++ b/secretsmanager/data_source_database_credentials.go
@@ -113,6 +113,7 @@ func dataSourceDatabaseCredentials() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -161,6 +162,11 @@ func dataSourceDatabaseCredentialsRead(ctx context.Context, d *schema.ResourceDa
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_driver_license.go
+++ b/secretsmanager/data_source_driver_license.go
@@ -163,6 +163,7 @@ func dataSourceDriverLicense() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -235,6 +236,11 @@ func dataSourceDriverLicenseRead(ctx context.Context, d *schema.ResourceData, m 
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_encrypted_notes.go
+++ b/secretsmanager/data_source_encrypted_notes.go
@@ -91,6 +91,7 @@ func dataSourceEncryptedNotes() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -137,6 +138,11 @@ func dataSourceEncryptedNotesRead(ctx context.Context, d *schema.ResourceData, m
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_health_insurance.go
+++ b/secretsmanager/data_source_health_insurance.go
@@ -123,6 +123,7 @@ func dataSourceHealthInsurance() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -175,6 +176,11 @@ func dataSourceHealthInsuranceRead(ctx context.Context, d *schema.ResourceData, 
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_login.go
+++ b/secretsmanager/data_source_login.go
@@ -119,6 +119,7 @@ func dataSourceLogin() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -179,6 +180,11 @@ func dataSourceLoginRead(ctx context.Context, d *schema.ResourceData, m interfac
 		}
 	}
 	if err := d.Set("totp", totpItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_login_custom_fields_test.go
+++ b/secretsmanager/data_source_login_custom_fields_test.go
@@ -1,0 +1,52 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+// TestAccDataSourceLogin_customFields verifies that custom fields written to a
+// resource are readable back through the corresponding data source.
+func TestAccDataSourceLogin_customFields(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_ds_custom_fields"
+
+	config := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_ds" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Environment"
+				value = "production"
+			}
+		}
+
+		data "secretsmanager_login" "custom_ds" {
+			path       = secretsmanager_login.custom_ds.uid
+			depends_on = [secretsmanager_login.custom_ds]
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.secretsmanager_login.custom_ds", "custom.#", "1"),
+					resource.TestCheckResourceAttr("data.secretsmanager_login.custom_ds", "custom.0.type", "text"),
+					resource.TestCheckResourceAttr("data.secretsmanager_login.custom_ds", "custom.0.label", "Environment"),
+					resource.TestCheckResourceAttr("data.secretsmanager_login.custom_ds", "custom.0.value", "production"),
+				),
+			},
+		},
+	})
+}

--- a/secretsmanager/data_source_membership.go
+++ b/secretsmanager/data_source_membership.go
@@ -113,6 +113,7 @@ func dataSourceMembership() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -159,6 +160,11 @@ func dataSourceMembershipRead(ctx context.Context, d *schema.ResourceData, m int
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_pam_database.go
+++ b/secretsmanager/data_source_pam_database.go
@@ -50,6 +50,7 @@ func dataSourcePamDatabase() *schema.Resource {
 			"provider_region":  schemaTextField(),
 			"file_ref":         schemaFileRefField(),
 			"totp":             schemaOneTimeCodeField(),
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -143,6 +144,11 @@ func dataSourcePamDatabaseRead(ctx context.Context, d *schema.ResourceData, m in
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_pam_directory.go
+++ b/secretsmanager/data_source_pam_directory.go
@@ -54,6 +54,7 @@ func dataSourcePamDirectory() *schema.Resource {
 			"alternative_ips":    schemaMultilineField(),
 			"file_ref":           schemaFileRefField(),
 			"totp":               schemaOneTimeCodeField(),
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -162,6 +163,11 @@ func dataSourcePamDirectoryRead(ctx context.Context, d *schema.ResourceData, m i
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_pam_remote_browser.go
+++ b/secretsmanager/data_source_pam_remote_browser.go
@@ -49,6 +49,7 @@ func dataSourcePamRemoteBrowser() *schema.Resource {
 			"traffic_encryption_seed": schemaTextField(),
 			"file_ref":                schemaFileRefField(),
 			"totp":                    schemaOneTimeCodeField(),
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -148,6 +149,11 @@ func dataSourcePamRemoteBrowserRead(ctx context.Context, d *schema.ResourceData,
 	}
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_passport.go
+++ b/secretsmanager/data_source_passport.go
@@ -174,6 +174,7 @@ func dataSourcePassport() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -258,6 +259,11 @@ func dataSourcePassportRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_photo.go
+++ b/secretsmanager/data_source_photo.go
@@ -78,6 +78,7 @@ func dataSourcePhoto() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -111,6 +112,11 @@ func dataSourcePhotoRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_server_credentials.go
+++ b/secretsmanager/data_source_server_credentials.go
@@ -108,6 +108,7 @@ func dataSourceServerCredentials() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -153,6 +154,11 @@ func dataSourceServerCredentialsRead(ctx context.Context, d *schema.ResourceData
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_software_license.go
+++ b/secretsmanager/data_source_software_license.go
@@ -95,6 +95,7 @@ func dataSourceSoftwareLicense() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -149,6 +150,11 @@ func dataSourceSoftwareLicenseRead(ctx context.Context, d *schema.ResourceData, 
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_ssh_keys.go
+++ b/secretsmanager/data_source_ssh_keys.go
@@ -128,6 +128,7 @@ func dataSourceSshKeys() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -179,6 +180,11 @@ func dataSourceSshKeysRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/data_source_ssn_card.go
+++ b/secretsmanager/data_source_ssn_card.go
@@ -107,6 +107,7 @@ func dataSourceSsnCard() *schema.Resource {
 					},
 				},
 			},
+			"custom": schemaCustomFieldData(),
 		},
 	}
 }
@@ -149,6 +150,11 @@ func dataSourceSsnCardRead(ctx context.Context, d *schema.ResourceData, m interf
 
 	fileItems := getFileItemsData(secret.Files)
 	if err := d.Set("file_ref", fileItems); err != nil {
+		return diag.FromErr(err)
+	}
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	if err := d.Set("custom", customItems); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/secretsmanager/ephemeral_address.go
+++ b/secretsmanager/ephemeral_address.go
@@ -25,6 +25,7 @@ type ephemeralAddressModel struct {
 	Notes   types.String `tfsdk:"notes"`
 	Address types.List   `tfsdk:"address"`
 	FileRef types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralAddress() ephemeral.EphemeralResource {
@@ -58,6 +59,7 @@ func (e *ephemeralAddress) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			},
 			"address":  addressEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -117,6 +119,12 @@ func (e *ephemeralAddress) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_bank_account.go
+++ b/secretsmanager/ephemeral_bank_account.go
@@ -31,6 +31,7 @@ type ephemeralBankAccountModel struct {
 	CardRef     types.List   `tfsdk:"card_ref"`
 	FileRef     types.List   `tfsdk:"file_ref"`
 	TOTP        types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralBankAccount() ephemeral.EphemeralResource {
@@ -100,6 +101,7 @@ func (e *ephemeralBankAccount) Schema(_ context.Context, _ ephemeral.SchemaReque
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -175,6 +177,12 @@ func (e *ephemeralBankAccount) Open(ctx context.Context, req ephemeral.OpenReque
 	totpList, diags := totpToListValue(ctx, totpUrl)
 	resp.Diagnostics.Append(diags...)
 	data.TOTP = totpList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_bank_card.go
+++ b/secretsmanager/ephemeral_bank_card.go
@@ -28,6 +28,7 @@ type ephemeralBankCardModel struct {
 	PinCode         types.String `tfsdk:"pin_code"`
 	AddressRef      types.List   `tfsdk:"address_ref"`
 	FileRef         types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralBankCard() ephemeral.EphemeralResource {
@@ -70,6 +71,7 @@ func (e *ephemeralBankCard) Schema(_ context.Context, _ ephemeral.SchemaRequest,
 			},
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -135,6 +137,12 @@ func (e *ephemeralBankCard) Open(ctx context.Context, req ephemeral.OpenRequest,
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_birth_certificate.go
+++ b/secretsmanager/ephemeral_birth_certificate.go
@@ -26,6 +26,7 @@ type ephemeralBirthCertificateModel struct {
 	Name      types.List   `tfsdk:"name"`
 	BirthDate types.String `tfsdk:"birth_date"`
 	FileRef   types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralBirthCertificate() ephemeral.EphemeralResource {
@@ -63,6 +64,7 @@ func (e *ephemeralBirthCertificate) Schema(_ context.Context, _ ephemeral.Schema
 				Description: "Date of birth.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -123,6 +125,12 @@ func (e *ephemeralBirthCertificate) Open(ctx context.Context, req ephemeral.Open
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_contact.go
+++ b/secretsmanager/ephemeral_contact.go
@@ -29,6 +29,7 @@ type ephemeralContactModel struct {
 	Phone      types.List   `tfsdk:"phone"`
 	AddressRef types.List   `tfsdk:"address_ref"`
 	FileRef    types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralContact() ephemeral.EphemeralResource {
@@ -72,6 +73,7 @@ func (e *ephemeralContact) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			"phone":       phoneEphemeralAttribute(),
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -141,6 +143,12 @@ func (e *ephemeralContact) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_database_credentials.go
+++ b/secretsmanager/ephemeral_database_credentials.go
@@ -28,6 +28,7 @@ type ephemeralDatabaseCredentialsModel struct {
 	Password types.String `tfsdk:"password"`
 	Host     types.List   `tfsdk:"host"`
 	FileRef  types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralDatabaseCredentials() ephemeral.EphemeralResource {
@@ -74,6 +75,7 @@ func (e *ephemeralDatabaseCredentials) Schema(_ context.Context, _ ephemeral.Sch
 			},
 			"host":     hostEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -136,6 +138,12 @@ func (e *ephemeralDatabaseCredentials) Open(ctx context.Context, req ephemeral.O
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_driver_license.go
+++ b/secretsmanager/ephemeral_driver_license.go
@@ -29,6 +29,7 @@ type ephemeralDriverLicenseModel struct {
 	ExpirationDate      types.String `tfsdk:"expiration_date"`
 	AddressRef          types.List   `tfsdk:"address_ref"`
 	FileRef             types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralDriverLicense() ephemeral.EphemeralResource {
@@ -75,6 +76,7 @@ func (e *ephemeralDriverLicense) Schema(_ context.Context, _ ephemeral.SchemaReq
 			},
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -141,6 +143,12 @@ func (e *ephemeralDriverLicense) Open(ctx context.Context, req ephemeral.OpenReq
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_encrypted_notes.go
+++ b/secretsmanager/ephemeral_encrypted_notes.go
@@ -26,6 +26,7 @@ type ephemeralEncryptedNotesModel struct {
 	Note    types.String `tfsdk:"note"`
 	Date    types.String `tfsdk:"date"`
 	FileRef types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralEncryptedNotes() ephemeral.EphemeralResource {
@@ -67,6 +68,7 @@ func (e *ephemeralEncryptedNotes) Schema(_ context.Context, _ ephemeral.SchemaRe
 				Description: "Date.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -124,6 +126,12 @@ func (e *ephemeralEncryptedNotes) Open(ctx context.Context, req ephemeral.OpenRe
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_health_insurance.go
+++ b/secretsmanager/ephemeral_health_insurance.go
@@ -29,6 +29,7 @@ type ephemeralHealthInsuranceModel struct {
 	Password      types.String `tfsdk:"password"`
 	URL           types.String `tfsdk:"url"`
 	FileRef       types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralHealthInsurance() ephemeral.EphemeralResource {
@@ -79,6 +80,7 @@ func (e *ephemeralHealthInsurance) Schema(_ context.Context, _ ephemeral.SchemaR
 				Description: "The secret url.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -142,6 +144,12 @@ func (e *ephemeralHealthInsurance) Open(ctx context.Context, req ephemeral.OpenR
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_login.go
+++ b/secretsmanager/ephemeral_login.go
@@ -28,6 +28,7 @@ type ephemeralLoginModel struct {
 	URL      types.String `tfsdk:"url"`
 	FileRef  types.List   `tfsdk:"file_ref"`
 	TOTP     types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralLogin() ephemeral.EphemeralResource {
@@ -94,6 +95,7 @@ func (e *ephemeralLogin) Schema(_ context.Context, _ ephemeral.SchemaRequest, re
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -157,6 +159,12 @@ func (e *ephemeralLogin) Open(ctx context.Context, req ephemeral.OpenRequest, re
 	totpList, diags := totpToListValue(ctx, totpUrl)
 	resp.Diagnostics.Append(diags...)
 	data.TOTP = totpList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_login_custom_fields_test.go
+++ b/secretsmanager/ephemeral_login_custom_fields_test.go
@@ -36,6 +36,27 @@ func TestAccEphemeralLogin_customFields(t *testing.T) {
 		ephemeral "secretsmanager_login" "custom_eph" {
 			path = "%v"
 		}
+
+		# check blocks can reference ephemeral values; a failed assertion surfaces
+		# as an apply-time warning and causes terraform test (.tftest.hcl) to fail.
+		check "ephemeral_custom_fields" {
+			assert {
+				condition     = length(ephemeral.secretsmanager_login.custom_eph.custom) == 1
+				error_message = "expected 1 custom field, got ${length(ephemeral.secretsmanager_login.custom_eph.custom)}"
+			}
+			assert {
+				condition     = ephemeral.secretsmanager_login.custom_eph.custom[0].type == "text"
+				error_message = "expected custom[0].type == \"text\""
+			}
+			assert {
+				condition     = ephemeral.secretsmanager_login.custom_eph.custom[0].label == "Environment"
+				error_message = "expected custom[0].label == \"Environment\""
+			}
+			assert {
+				condition     = ephemeral.secretsmanager_login.custom_eph.custom[0].value == "production"
+				error_message = "expected custom[0].value == \"production\""
+			}
+		}
 	`, secretUid)
 
 	resource.Test(t, resource.TestCase{

--- a/secretsmanager/ephemeral_login_custom_fields_test.go
+++ b/secretsmanager/ephemeral_login_custom_fields_test.go
@@ -1,0 +1,49 @@
+package secretsmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/keeper-security/secrets-manager-go/core"
+)
+
+// TestAccEphemeralLogin_customFields verifies that a login record with custom
+// fields can be read through the ephemeral resource without error. Uses two
+// steps: step 1 creates the resource; step 2 reads it with the ephemeral
+// resource. This avoids a pre-apply refresh failure caused by uid being a
+// known value at plan time before the record exists.
+func TestAccEphemeralLogin_customFields(t *testing.T) {
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	secretTitle := "tf_acc_eph_custom_fields"
+
+	configResource := fmt.Sprintf(`
+		resource "secretsmanager_login" "custom_eph" {
+			folder_uid = "%v"
+			uid        = "%v"
+			title      = "%v"
+
+			custom {
+				type  = "text"
+				label = "Environment"
+				value = "production"
+			}
+		}
+	`, secretFolderUid, secretUid, secretTitle)
+
+	configWithEphemeral := configResource + fmt.Sprintf(`
+		ephemeral "secretsmanager_login" "custom_eph" {
+			path = "%v"
+		}
+	`, secretUid)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{Config: configResource},
+			{Config: configWithEphemeral},
+		},
+	})
+}

--- a/secretsmanager/ephemeral_membership.go
+++ b/secretsmanager/ephemeral_membership.go
@@ -27,6 +27,7 @@ type ephemeralMembershipModel struct {
 	Name          types.List   `tfsdk:"name"`
 	Password      types.String `tfsdk:"password"`
 	FileRef       types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralMembership() ephemeral.EphemeralResource {
@@ -69,6 +70,7 @@ func (e *ephemeralMembership) Schema(_ context.Context, _ ephemeral.SchemaReques
 				Description: "The secret password.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -130,6 +132,12 @@ func (e *ephemeralMembership) Open(ctx context.Context, req ephemeral.OpenReques
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_database.go
+++ b/secretsmanager/ephemeral_pam_database.go
@@ -33,6 +33,7 @@ type ephemeralPamDatabaseModel struct {
 	ProviderRegion types.String `tfsdk:"provider_region"`
 	FileRef        types.List   `tfsdk:"file_ref"`
 	TOTP           types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamDatabase() ephemeral.EphemeralResource {
@@ -115,6 +116,7 @@ func (e *ephemeralPamDatabase) Schema(_ context.Context, _ ephemeral.SchemaReque
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -192,6 +194,12 @@ func (e *ephemeralPamDatabase) Open(ctx context.Context, req ephemeral.OpenReque
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_directory.go
+++ b/secretsmanager/ephemeral_pam_directory.go
@@ -37,6 +37,7 @@ type ephemeralPamDirectoryModel struct {
 	AlternativeIPs    types.String `tfsdk:"alternative_ips"`
 	FileRef           types.List   `tfsdk:"file_ref"`
 	TOTP              types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamDirectory() ephemeral.EphemeralResource {
@@ -135,6 +136,7 @@ func (e *ephemeralPamDirectory) Schema(_ context.Context, _ ephemeral.SchemaRequ
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -216,6 +218,12 @@ func (e *ephemeralPamDirectory) Open(ctx context.Context, req ephemeral.OpenRequ
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_machine.go
+++ b/secretsmanager/ephemeral_pam_machine.go
@@ -38,6 +38,7 @@ type ephemeralPamMachineModel struct {
 	ProviderRegion       types.String `tfsdk:"provider_region"`
 	FileRef              types.List   `tfsdk:"file_ref"`
 	TOTP                 types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamMachine() ephemeral.EphemeralResource {
@@ -143,6 +144,7 @@ func (e *ephemeralPamMachine) Schema(_ context.Context, _ ephemeral.SchemaReques
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -225,6 +227,12 @@ func (e *ephemeralPamMachine) Open(ctx context.Context, req ephemeral.OpenReques
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_remote_browser.go
+++ b/secretsmanager/ephemeral_pam_remote_browser.go
@@ -29,6 +29,7 @@ type ephemeralPamRemoteBrowserModel struct {
 	TrafficEncryptionSeed     types.String `tfsdk:"traffic_encryption_seed"`
 	FileRef                   types.List   `tfsdk:"file_ref"`
 	TOTP                      types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamRemoteBrowser() ephemeral.EphemeralResource {
@@ -99,6 +100,7 @@ func (e *ephemeralPamRemoteBrowser) Schema(_ context.Context, _ ephemeral.Schema
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -184,6 +186,12 @@ func (e *ephemeralPamRemoteBrowser) Open(ctx context.Context, req ephemeral.Open
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_user.go
+++ b/secretsmanager/ephemeral_pam_user.go
@@ -33,6 +33,7 @@ type ephemeralPamUserModel struct {
 	Managed              types.Bool   `tfsdk:"managed"`
 	FileRef              types.List   `tfsdk:"file_ref"`
 	TOTP                 types.List   `tfsdk:"totp"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamUser() ephemeral.EphemeralResource {
@@ -121,6 +122,7 @@ func (e *ephemeralPamUser) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 					},
 				},
 			},
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -195,6 +197,12 @@ func (e *ephemeralPamUser) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_passport.go
+++ b/secretsmanager/ephemeral_passport.go
@@ -31,6 +31,7 @@ type ephemeralPassportModel struct {
 	Password       types.String `tfsdk:"password"`
 	AddressRef     types.List   `tfsdk:"address_ref"`
 	FileRef        types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPassport() ephemeral.EphemeralResource {
@@ -86,6 +87,7 @@ func (e *ephemeralPassport) Schema(_ context.Context, _ ephemeral.SchemaRequest,
 			},
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -154,6 +156,12 @@ func (e *ephemeralPassport) Open(ctx context.Context, req ephemeral.OpenRequest,
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_photo.go
+++ b/secretsmanager/ephemeral_photo.go
@@ -24,6 +24,7 @@ type ephemeralPhotoModel struct {
 	Title   types.String `tfsdk:"title"`
 	Notes   types.String `tfsdk:"notes"`
 	FileRef types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPhoto() ephemeral.EphemeralResource {
@@ -56,6 +57,7 @@ func (e *ephemeralPhoto) Schema(_ context.Context, _ ephemeral.SchemaRequest, re
 				Description: "The secret notes.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -111,6 +113,12 @@ func (e *ephemeralPhoto) Open(ctx context.Context, req ephemeral.OpenRequest, re
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_server_credentials.go
+++ b/secretsmanager/ephemeral_server_credentials.go
@@ -27,6 +27,7 @@ type ephemeralServerCredentialsModel struct {
 	Login    types.String `tfsdk:"login"`
 	Password types.String `tfsdk:"password"`
 	FileRef  types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralServerCredentials() ephemeral.EphemeralResource {
@@ -69,6 +70,7 @@ func (e *ephemeralServerCredentials) Schema(_ context.Context, _ ephemeral.Schem
 			},
 			"host":     hostEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -130,6 +132,12 @@ func (e *ephemeralServerCredentials) Open(ctx context.Context, req ephemeral.Ope
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_software_license.go
+++ b/secretsmanager/ephemeral_software_license.go
@@ -27,6 +27,7 @@ type ephemeralSoftwareLicenseModel struct {
 	ActivationDate types.String `tfsdk:"activation_date"`
 	ExpirationDate types.String `tfsdk:"expiration_date"`
 	FileRef        types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralSoftwareLicense() ephemeral.EphemeralResource {
@@ -71,6 +72,7 @@ func (e *ephemeralSoftwareLicense) Schema(_ context.Context, _ ephemeral.SchemaR
 				Description: "Date of expiration.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -130,6 +132,12 @@ func (e *ephemeralSoftwareLicense) Open(ctx context.Context, req ephemeral.OpenR
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_ssh_keys.go
+++ b/secretsmanager/ephemeral_ssh_keys.go
@@ -28,6 +28,7 @@ type ephemeralSshKeysModel struct {
 	Passphrase types.String `tfsdk:"passphrase"`
 	Host       types.List   `tfsdk:"host"`
 	FileRef    types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralSshKeys() ephemeral.EphemeralResource {
@@ -87,6 +88,7 @@ func (e *ephemeralSshKeys) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			},
 			"host":     hostEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -152,6 +154,12 @@ func (e *ephemeralSshKeys) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_ssn_card.go
+++ b/secretsmanager/ephemeral_ssn_card.go
@@ -26,6 +26,7 @@ type ephemeralSsnCardModel struct {
 	IdentityNumber types.String `tfsdk:"identity_number"`
 	Name           types.List   `tfsdk:"name"`
 	FileRef        types.List   `tfsdk:"file_ref"`
+	Custom  types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralSsnCard() ephemeral.EphemeralResource {
@@ -63,6 +64,7 @@ func (e *ephemeralSsnCard) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			},
 			"name":     nameEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
+			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -123,6 +125,12 @@ func (e *ephemeralSsnCard) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	fileRefList, diags := fileItemsToListValue(ctx, secret.Files)
 	resp.Diagnostics.Append(diags...)
 	data.FileRef = fileRefList
+
+	customItems := getFieldItemsData(secret.RecordDict, "custom")
+	customList, diags := genericFieldItemsToListValue(ctx, customItems)
+	resp.Diagnostics.Append(diags...)
+	data.Custom = customList
+
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/record_fields.go
+++ b/secretsmanager/record_fields.go
@@ -1527,6 +1527,47 @@ func schemaUrlField() *schema.Schema {
 // schemaCustomField returns the schema for user-defined custom fields on a record.
 // Each field has a type, label, and value. The value is always a string:
 // - Simple types (text, multiline, secret, url, email): plain string value
+// schemaCustomFieldData returns the read-only schema for the custom block used in data sources and
+// ephemeral resources. Unlike schemaCustomField(), all sub-fields are Computed because the data
+// originates from the vault and is never written by Terraform.
+func schemaCustomFieldData() *schema.Schema {
+	return &schema.Schema{
+		Type:        schema.TypeList,
+		Computed:    true,
+		Description: "Custom fields defined by the user in Keeper. Each field has a type, label, and value.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field type (e.g. text, secret, url, email, phone, paymentCard).",
+				},
+				"label": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Description: "Field label.",
+				},
+				"value": {
+					Type:        schema.TypeString,
+					Computed:    true,
+					Sensitive:   true,
+					Description: "Field value. Complex types (phone, name, address, paymentCard) are returned as JSON.",
+				},
+				"required": {
+					Type:        schema.TypeBool,
+					Computed:    true,
+					Description: "Whether this field is required.",
+				},
+				"privacy_screen": {
+					Type:        schema.TypeBool,
+					Computed:    true,
+					Description: "Whether this field is hidden behind a privacy screen in the Keeper UI.",
+				},
+			},
+		},
+	}
+}
+
 // - Complex types (phone, name, address, paymentCard): jsonencode() of the nested object
 // - Date: YYYY-MM-DD format (e.g. "2024-01-15")
 // The provider interprets the value based on the type field.


### PR DESCRIPTION
## What

Adds a read-only `custom` block to all 20 record-type **data sources** and all 22 record-type **ephemeral resources**, completing custom field support across all three resource layers.

This was requested in issue #16 by @bcsgh: *"Does the above PR include being able to read custom values back out from `data` and `ephemeral` resources?"*

## Why

KSM-388 added the `custom` block (write path) to all 23 resource types. Data sources and ephemeral resources had no way to read custom fields back — `data "secretsmanager_login"` silently dropped them. Users who write custom fields via managed resources had no way to read them without switching to a managed resource dependency.

## How

**Data sources (SDKv2):**
- Add `schemaCustomFieldData()` — a Computed-only variant of `schemaCustomField()` with no `StateFunc` or `ValidateDiagFunc` (read path needs neither)
- Add `getFieldItemsData(secret.RecordDict, "custom")` call in each `ReadContext`, followed by `d.Set("custom", ...)`

**Ephemeral resources (Plugin Framework):**
- Add `Custom types.List \`tfsdk:"custom"\`` to each model struct
- Add `"custom": genericFieldEphemeralAttribute(...)` in each `Schema()` method
- Add `genericFieldItemsToListValue()` call in each `Open()` method to populate `data.Custom`

**New helpers reuse existing code** — `getFieldItemsData` already existed in `provider.go` for the resource read path; `genericFieldEphemeralAttribute` and `genericFieldItemsToListValue` already existed for other ephemeral fields.

## Schema

Each `custom` entry is a read-only block:

```hcl
data "secretsmanager_login" "example" {
  path = "UID_HERE"
}

output "custom_fields" {
  value = data.secretsmanager_login.example.custom
  # → [{type="text", label="Environment", value="production", required=false, privacy_screen=false}, ...]
}
```

## Testing

**Unit tests (no vault):**
- `TestCustomFieldDataSourceSchemaPresence` — verifies all 20 data source schemas contain `custom` TypeList with correct 5-key structure
- `TestCustomFieldEphemeralSchemaPresence` — verifies all 22 ephemeral resource schemas contain `custom` attribute

**Acceptance tests:**
- `TestAccDataSourceLogin_customFields` — creates a login with a custom text field, reads it back via data source, asserts `custom.0.type`, `custom.0.label`, `custom.0.value`
- `TestAccEphemeralLogin_customFields` — 2-step test (step 1 creates resource; step 2 opens ephemeral) — avoids pre-apply refresh failure caused by user-provided UID being a known value before the record exists

**Live test against production vault:**
- Pointed dev binary at a login record with 3 confirmed custom fields (`Environment`, `Database Name`, `Last Updated`)
- `terraform plan` returned all 3 fields with correct type/label/value/required/privacy_screen

## Files changed

- `secretsmanager/record_fields.go` — add `schemaCustomFieldData()`
- `secretsmanager/data_source_*.go` (20 files) — add schema key + `d.Set("custom", ...)`
- `secretsmanager/ephemeral_*.go` (22 files) — add struct field + schema attribute + `Open()` population
- `secretsmanager/custom_fields_data_source_schema_test.go` (new) — schema presence unit tests
- `secretsmanager/data_source_login_custom_fields_test.go` (new) — data source acceptance test
- `secretsmanager/ephemeral_login_custom_fields_test.go` (new) — ephemeral acceptance test
- `CHANGELOG.md` — document under [1.3.0] Added

> **Reviewer note:** The 47-file diff is highly uniform — each data source file gets the same 3 lines added in the same place; each ephemeral file gets the same 4 lines in 3 locations. Recommend reviewing one data source + one ephemeral file in detail, then spot-checking pam_machine and pam_user (which previously had `"custom"` as a string in `pamFieldStringWithLabel` but were missing the actual schema attribute — caught and fixed by the unit test).