### PR TITLE
fix(KSM-915): remove path write-back in ephemeral_field Open()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PAM Remote Browser example file** (Code Review):
   - Created `examples/resources/pam_remote_browser.tf` demonstrating managed resource with `custom` block support
 
+- **`secretsmanager_field` ephemeral resource — wildcard path crash** (KSM-915):
+  - Using `path = "*/field/login"` with `title` caused apply to fail with "Provider produced invalid ephemeral resource instance — planned value does not match config value"
+  - Terraform Plugin Framework enforces that `Required` (non-`Computed`) attributes cannot be mutated by the provider; the resolved UID was being written back to `path` in violation of this rule
+  - Fix: remove the internal path write-back; `value` is the only attribute that needs to be set in the result
+
 - **Custom fields — type case normalization and validation** (KSM-908):
   - Custom field `type` input is now case-insensitive; any casing (e.g., `"paymentcard"`, `"PaymentCard"`, `"PAYMENTCARD"`) is accepted and normalized to canonical vault API casing — no perpetual diff
   - Unknown type strings are now rejected at plan time with a clear error listing all valid types

--- a/docs/ephemeral-resources/field.md
+++ b/docs/ephemeral-resources/field.md
@@ -15,6 +15,17 @@ output "field_value" {
   value     = ephemeral.secretsmanager_field.my_field.value
   ephemeral = true
 }
+
+# Look up by record title instead of UID — use * as a placeholder
+ephemeral "secretsmanager_field" "by_title" {
+  path  = "*/field/login"
+  title = "My Record Title"
+}
+
+output "field_value_by_title" {
+  value     = ephemeral.secretsmanager_field.by_title.value
+  ephemeral = true
+}
 ```
 
 ## Argument Reference

--- a/examples/ephemeral-resources/field.tf
+++ b/examples/ephemeral-resources/field.tf
@@ -23,3 +23,14 @@ output "field_value" {
   value     = ephemeral.secretsmanager_field.my_field.value
   ephemeral = true
 }
+
+# Look up by record title instead of UID — use * as a placeholder
+ephemeral "secretsmanager_field" "by_title" {
+  path  = "*/field/login"
+  title = "My Record Title"
+}
+
+output "field_value_by_title" {
+  value     = ephemeral.secretsmanager_field.by_title.value
+  ephemeral = true
+}

--- a/secretsmanager/ephemeral_field.go
+++ b/secretsmanager/ephemeral_field.go
@@ -119,7 +119,6 @@ func (e *ephemeralField) Open(ctx context.Context, req ephemeral.OpenRequest, re
 		strValue = fmt.Sprintf("%v", value)
 	}
 
-	data.Path = types.StringValue(path)
 	data.Value = types.StringValue(strValue)
 
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)


### PR DESCRIPTION
## Summary

Removes the `data.Path = types.StringValue(path)` write-back in `ephemeral_field.Open()`. Terraform Plugin Framework enforces that non-Computed `Required` attributes cannot be mutated by the provider — writing the wildcard-resolved path back caused a planned-vs-config value mismatch and crashed apply for any `*`-wildcard path.

## Changes

### Fixed
- `secretsmanager_field` ephemeral resource crashes with "Provider produced invalid ephemeral resource instance" when `path` contains a `*` wildcard (KSM-915)

## Breaking Changes
None.

## Related Issues
- Jira: KSM-915