### PR TITLE
fix(ci): prevent shell injection in release workflow failure handler

### DIFF
--- a/.github/workflows/terraform-provider-release-process.yml
+++ b/.github/workflows/terraform-provider-release-process.yml
@@ -223,4 +223,6 @@ jobs:
 
       - name: Delete tag on build failure
         if: failure()
-        run: git push --delete origin ${{ steps.set-tag.outputs.tag_name }}
+        env:
+          TAG_NAME: ${{ steps.set-tag.outputs.tag_name }}
+        run: git push --delete origin "$TAG_NAME"


### PR DESCRIPTION
## Summary

- Adds an `env:` block to the "Delete tag on build failure" step and routes `steps.set-tag.outputs.tag_name` through `\$TAG_NAME` instead of inlining the `\${{ }}` expression directly in the `run:` shell command.
- Proactive hardening identified while addressing a related Bugcrowd report (VM-111) in the `secrets-manager` repo: the step output is derived from `workflow_dispatch` user input and could be crafted to execute arbitrary commands when GoReleaser fails.

## Security context

- **Vulnerability class**: GHA expression injection via step output derived from user input
- **Existing mitigations**: `environment: prod` approval gate + only reachable on GoReleaser failure path
- **Fix**: Intermediate `env:` variable -- value is stored in process memory and never participates in script generation

## Breaking Changes

None -- purely a workflow hardening change with no behavioral difference under normal inputs.