### PR TITLE
fix(ci): run test workflow on master and release PRs (KSM-1028)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test-Terraform-Provider
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ master, "release-**" ]
 
   workflow_dispatch:
 

--- a/secretsmanager/custom_fields_unit_test.go
+++ b/secretsmanager/custom_fields_unit_test.go
@@ -20,9 +20,9 @@ import (
 // any local timezone behind UTC would return the previous day without the fix.
 func TestEpochMsToDateUTC(t *testing.T) {
 	tests := []struct {
-		name  string
-		ms    float64
-		want  string
+		name string
+		ms   float64
+		want string
 	}{
 		{
 			// 2025-01-01T00:00:00Z — midnight UTC, New Year's Day.

--- a/secretsmanager/data_source_address_test.go
+++ b/secretsmanager/data_source_address_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceAddress(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_bank_account_test.go
+++ b/secretsmanager/data_source_bank_account_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceBankAccount(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_bank_card_test.go
+++ b/secretsmanager/data_source_bank_card_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceBankCard(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_birth_certificate_test.go
+++ b/secretsmanager/data_source_birth_certificate_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceBirthCertificate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_contact_test.go
+++ b/secretsmanager/data_source_contact_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceContact(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_database_credentials_test.go
+++ b/secretsmanager/data_source_database_credentials_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceDatabaseCredentials(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_driver_license_test.go
+++ b/secretsmanager/data_source_driver_license_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceDriverLicense(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_encrypted_notes_test.go
+++ b/secretsmanager/data_source_encrypted_notes_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceEncryptedNotes(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_field_test.go
+++ b/secretsmanager/data_source_field_test.go
@@ -22,7 +22,7 @@ func TestAccDataSourceField(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_file_test.go
+++ b/secretsmanager/data_source_file_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceFile(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_folder_test.go
+++ b/secretsmanager/data_source_folder_test.go
@@ -73,7 +73,7 @@ func TestAccDataSourceFolder(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_folders_test.go
+++ b/secretsmanager/data_source_folders_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceFolders(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_health_insurance_test.go
+++ b/secretsmanager/data_source_health_insurance_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceHealthInsurance(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_login_test.go
+++ b/secretsmanager/data_source_login_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceLogin(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_membership_test.go
+++ b/secretsmanager/data_source_membership_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceMembership(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_pam_database.go
+++ b/secretsmanager/data_source_pam_database.go
@@ -50,7 +50,7 @@ func dataSourcePamDatabase() *schema.Resource {
 			"provider_region":  schemaTextField(),
 			"file_ref":         schemaFileRefField(),
 			"totp":             schemaOneTimeCodeField(),
-			"custom": schemaCustomFieldData(),
+			"custom":           schemaCustomFieldData(),
 		},
 	}
 }

--- a/secretsmanager/data_source_pam_database_test.go
+++ b/secretsmanager/data_source_pam_database_test.go
@@ -66,7 +66,7 @@ func TestAccDataSourcePamDatabase(t *testing.T) {
 	dataName := fmt.Sprintf("data.secretsmanager_pam_database.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_pam_directory.go
+++ b/secretsmanager/data_source_pam_directory.go
@@ -54,7 +54,7 @@ func dataSourcePamDirectory() *schema.Resource {
 			"alternative_ips":    schemaMultilineField(),
 			"file_ref":           schemaFileRefField(),
 			"totp":               schemaOneTimeCodeField(),
-			"custom": schemaCustomFieldData(),
+			"custom":             schemaCustomFieldData(),
 		},
 	}
 }

--- a/secretsmanager/data_source_pam_directory_test.go
+++ b/secretsmanager/data_source_pam_directory_test.go
@@ -85,7 +85,7 @@ func TestAccDataSourcePamDirectory(t *testing.T) {
 	dataName := fmt.Sprintf("data.secretsmanager_pam_directory.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_pam_machine_test.go
+++ b/secretsmanager/data_source_pam_machine_test.go
@@ -89,7 +89,7 @@ func TestAccDataSourcePamMachine(t *testing.T) {
 	dataName := fmt.Sprintf("data.secretsmanager_pam_machine.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_pam_remote_browser.go
+++ b/secretsmanager/data_source_pam_remote_browser.go
@@ -49,7 +49,7 @@ func dataSourcePamRemoteBrowser() *schema.Resource {
 			"traffic_encryption_seed": schemaTextSensitiveField(),
 			"file_ref":                schemaFileRefField(),
 			"totp":                    schemaOneTimeCodeField(),
-			"custom": schemaCustomFieldData(),
+			"custom":                  schemaCustomFieldData(),
 		},
 	}
 }

--- a/secretsmanager/data_source_pam_remote_browser_test.go
+++ b/secretsmanager/data_source_pam_remote_browser_test.go
@@ -35,7 +35,7 @@ func TestAccDataSourcePamRemoteBrowser(t *testing.T) {
 	dataSourceName := fmt.Sprintf("data.secretsmanager_pam_remote_browser.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_pam_user_test.go
+++ b/secretsmanager/data_source_pam_user_test.go
@@ -64,7 +64,7 @@ func TestAccDataSourcePamUser(t *testing.T) {
 	dataName := fmt.Sprintf("data.secretsmanager_pam_user.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_passport_test.go
+++ b/secretsmanager/data_source_passport_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourcePassport(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_photo_test.go
+++ b/secretsmanager/data_source_photo_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourcePhoto(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_record_test.go
+++ b/secretsmanager/data_source_record_test.go
@@ -21,7 +21,7 @@ func TestAccDataSourceRecord(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_records_test.go
+++ b/secretsmanager/data_source_records_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAccDataSourceRecords_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -32,7 +32,7 @@ func TestAccDataSourceRecords_Basic(t *testing.T) {
 
 func TestAccDataSourceRecords_WithTitles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccDataSourceRecords_WithTitles(t *testing.T) {
 
 func TestAccDataSourceRecords_MultipleTitles(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -66,7 +66,7 @@ func TestAccDataSourceRecords_MultipleTitles(t *testing.T) {
 
 func TestAccDataSourceRecords_LargeBatch(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -158,7 +158,7 @@ data "secretsmanager_records" "test" {
 
 func TestAccDataSourceRecords_WithTitlePatterns(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -187,7 +187,7 @@ func TestAccDataSourceRecords_WithTitlePatterns(t *testing.T) {
 
 func TestAccDataSourceRecords_InvalidPattern(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -200,7 +200,7 @@ func TestAccDataSourceRecords_InvalidPattern(t *testing.T) {
 
 func TestAccDataSourceRecords_PatternTooLong(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -213,7 +213,7 @@ func TestAccDataSourceRecords_PatternTooLong(t *testing.T) {
 
 func TestAccDataSourceRecords_CombinedWithPatterns(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -242,7 +242,7 @@ func TestAccDataSourceRecords_CombinedWithPatterns(t *testing.T) {
 
 func TestAccDataSourceRecords_MultiplePatterns(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/data_source_server_credentials_test.go
+++ b/secretsmanager/data_source_server_credentials_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceServerCredentials(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_software_license_test.go
+++ b/secretsmanager/data_source_software_license_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceSoftwareLicense(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_ssh_keys_test.go
+++ b/secretsmanager/data_source_ssh_keys_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceSshKeys(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/data_source_ssn_card_test.go
+++ b/secretsmanager/data_source_ssn_card_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourceSsnCard(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/ephemeral_address.go
+++ b/secretsmanager/ephemeral_address.go
@@ -59,7 +59,7 @@ func (e *ephemeralAddress) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			},
 			"address":  addressEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -124,7 +124,6 @@ func (e *ephemeralAddress) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_address_test.go
+++ b/secretsmanager/ephemeral_address_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUaddress(t *testing.T) {
 	secretType := "address"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_bank_account.go
+++ b/secretsmanager/ephemeral_bank_account.go
@@ -31,7 +31,7 @@ type ephemeralBankAccountModel struct {
 	CardRef     types.List   `tfsdk:"card_ref"`
 	FileRef     types.List   `tfsdk:"file_ref"`
 	TOTP        types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom      types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralBankAccount() ephemeral.EphemeralResource {
@@ -182,7 +182,6 @@ func (e *ephemeralBankAccount) Open(ctx context.Context, req ephemeral.OpenReque
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_bank_account_test.go
+++ b/secretsmanager/ephemeral_bank_account_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUbankUaccount(t *testing.T) {
 	secretType := "bankAccount"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_bank_card.go
+++ b/secretsmanager/ephemeral_bank_card.go
@@ -19,16 +19,16 @@ type ephemeralBankCard struct {
 }
 
 type ephemeralBankCardModel struct {
-	Path            types.String `tfsdk:"path"`
-	Type            types.String `tfsdk:"type"`
-	Title           types.String `tfsdk:"title"`
-	Notes           types.String `tfsdk:"notes"`
-	PaymentCard     types.List   `tfsdk:"payment_card"`
-	CardholderName  types.String `tfsdk:"cardholder_name"`
-	PinCode         types.String `tfsdk:"pin_code"`
-	AddressRef      types.List   `tfsdk:"address_ref"`
-	FileRef         types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Path           types.String `tfsdk:"path"`
+	Type           types.String `tfsdk:"type"`
+	Title          types.String `tfsdk:"title"`
+	Notes          types.String `tfsdk:"notes"`
+	PaymentCard    types.List   `tfsdk:"payment_card"`
+	CardholderName types.String `tfsdk:"cardholder_name"`
+	PinCode        types.String `tfsdk:"pin_code"`
+	AddressRef     types.List   `tfsdk:"address_ref"`
+	FileRef        types.List   `tfsdk:"file_ref"`
+	Custom         types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralBankCard() ephemeral.EphemeralResource {
@@ -72,7 +72,7 @@ func (e *ephemeralBankCard) Schema(_ context.Context, _ ephemeral.SchemaRequest,
 			},
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":      genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -143,7 +143,6 @@ func (e *ephemeralBankCard) Open(ctx context.Context, req ephemeral.OpenRequest,
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_bank_card_test.go
+++ b/secretsmanager/ephemeral_bank_card_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUbankUcard(t *testing.T) {
 	secretType := "bankCard"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_birth_certificate.go
+++ b/secretsmanager/ephemeral_birth_certificate.go
@@ -26,7 +26,7 @@ type ephemeralBirthCertificateModel struct {
 	Name      types.List   `tfsdk:"name"`
 	BirthDate types.String `tfsdk:"birth_date"`
 	FileRef   types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom    types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralBirthCertificate() ephemeral.EphemeralResource {
@@ -64,7 +64,7 @@ func (e *ephemeralBirthCertificate) Schema(_ context.Context, _ ephemeral.Schema
 				Description: "Date of birth.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -130,7 +130,6 @@ func (e *ephemeralBirthCertificate) Open(ctx context.Context, req ephemeral.Open
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_birth_certificate_test.go
+++ b/secretsmanager/ephemeral_birth_certificate_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUbirthUcertificate(t *testing.T) {
 	secretType := "birthCertificate"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_contact.go
+++ b/secretsmanager/ephemeral_contact.go
@@ -29,7 +29,7 @@ type ephemeralContactModel struct {
 	Phone      types.List   `tfsdk:"phone"`
 	AddressRef types.List   `tfsdk:"address_ref"`
 	FileRef    types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom     types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralContact() ephemeral.EphemeralResource {
@@ -73,7 +73,7 @@ func (e *ephemeralContact) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			"phone":       phoneEphemeralAttribute(),
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":      genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -148,7 +148,6 @@ func (e *ephemeralContact) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_contact_test.go
+++ b/secretsmanager/ephemeral_contact_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUcontact(t *testing.T) {
 	secretType := "contact"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_database_credentials.go
+++ b/secretsmanager/ephemeral_database_credentials.go
@@ -28,7 +28,7 @@ type ephemeralDatabaseCredentialsModel struct {
 	Password types.String `tfsdk:"password"`
 	Host     types.List   `tfsdk:"host"`
 	FileRef  types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom   types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralDatabaseCredentials() ephemeral.EphemeralResource {
@@ -75,7 +75,7 @@ func (e *ephemeralDatabaseCredentials) Schema(_ context.Context, _ ephemeral.Sch
 			},
 			"host":     hostEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -143,7 +143,6 @@ func (e *ephemeralDatabaseCredentials) Open(ctx context.Context, req ephemeral.O
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_database_credentials_test.go
+++ b/secretsmanager/ephemeral_database_credentials_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralDatabaseCredentials(t *testing.T) {
 	secretType := "databaseCredentials"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_driver_license.go
+++ b/secretsmanager/ephemeral_driver_license.go
@@ -29,7 +29,7 @@ type ephemeralDriverLicenseModel struct {
 	ExpirationDate      types.String `tfsdk:"expiration_date"`
 	AddressRef          types.List   `tfsdk:"address_ref"`
 	FileRef             types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom              types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralDriverLicense() ephemeral.EphemeralResource {
@@ -76,7 +76,7 @@ func (e *ephemeralDriverLicense) Schema(_ context.Context, _ ephemeral.SchemaReq
 			},
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":      genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -148,7 +148,6 @@ func (e *ephemeralDriverLicense) Open(ctx context.Context, req ephemeral.OpenReq
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_driver_license_test.go
+++ b/secretsmanager/ephemeral_driver_license_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUdriverUlicense(t *testing.T) {
 	secretType := "driverLicense"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_encrypted_notes.go
+++ b/secretsmanager/ephemeral_encrypted_notes.go
@@ -68,7 +68,7 @@ func (e *ephemeralEncryptedNotes) Schema(_ context.Context, _ ephemeral.SchemaRe
 				Description: "Date.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -131,7 +131,6 @@ func (e *ephemeralEncryptedNotes) Open(ctx context.Context, req ephemeral.OpenRe
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_encrypted_notes_test.go
+++ b/secretsmanager/ephemeral_encrypted_notes_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUencryptedUnotes(t *testing.T) {
 	secretType := "encryptedNotes"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_field_test.go
+++ b/secretsmanager/ephemeral_field_test.go
@@ -12,7 +12,7 @@ func TestAccEphemeralField(t *testing.T) {
 	secretType := "field"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`
@@ -37,7 +37,7 @@ func TestAccEphemeralFieldByTitle(t *testing.T) {
 	secretType := "field"
 	_, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_file_test.go
+++ b/secretsmanager/ephemeral_file_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralFile(t *testing.T) {
 	secretType := "file"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_health_insurance.go
+++ b/secretsmanager/ephemeral_health_insurance.go
@@ -29,7 +29,7 @@ type ephemeralHealthInsuranceModel struct {
 	Password      types.String `tfsdk:"password"`
 	URL           types.String `tfsdk:"url"`
 	FileRef       types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom        types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralHealthInsurance() ephemeral.EphemeralResource {
@@ -80,7 +80,7 @@ func (e *ephemeralHealthInsurance) Schema(_ context.Context, _ ephemeral.SchemaR
 				Description: "The secret url.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -149,7 +149,6 @@ func (e *ephemeralHealthInsurance) Open(ctx context.Context, req ephemeral.OpenR
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_health_insurance_test.go
+++ b/secretsmanager/ephemeral_health_insurance_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUhealthUinsurance(t *testing.T) {
 	secretType := "healthInsurance"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_login.go
+++ b/secretsmanager/ephemeral_login.go
@@ -28,7 +28,7 @@ type ephemeralLoginModel struct {
 	URL      types.String `tfsdk:"url"`
 	FileRef  types.List   `tfsdk:"file_ref"`
 	TOTP     types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom   types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralLogin() ephemeral.EphemeralResource {
@@ -164,7 +164,6 @@ func (e *ephemeralLogin) Open(ctx context.Context, req ephemeral.OpenRequest, re
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_login_test.go
+++ b/secretsmanager/ephemeral_login_test.go
@@ -12,7 +12,7 @@ func TestAccEphemeralLogin(t *testing.T) {
 	secretType := "login"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`
@@ -37,7 +37,7 @@ func TestAccEphemeralLoginByTitle(t *testing.T) {
 	secretType := "login"
 	_, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`
@@ -62,7 +62,7 @@ func TestAccEphemeralLoginWrongType(t *testing.T) {
 	// Use a bankCard record UID with the login ephemeral resource — should error
 	secretUid, secretTitle := testAcc.getRecordInfo("bankCard")
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing bankCard UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_membership.go
+++ b/secretsmanager/ephemeral_membership.go
@@ -27,7 +27,7 @@ type ephemeralMembershipModel struct {
 	Name          types.List   `tfsdk:"name"`
 	Password      types.String `tfsdk:"password"`
 	FileRef       types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom        types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralMembership() ephemeral.EphemeralResource {
@@ -70,7 +70,7 @@ func (e *ephemeralMembership) Schema(_ context.Context, _ ephemeral.SchemaReques
 				Description: "The secret password.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -137,7 +137,6 @@ func (e *ephemeralMembership) Open(ctx context.Context, req ephemeral.OpenReques
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_membership_test.go
+++ b/secretsmanager/ephemeral_membership_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUmembership(t *testing.T) {
 	secretType := "membership"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_pam_database.go
+++ b/secretsmanager/ephemeral_pam_database.go
@@ -33,7 +33,7 @@ type ephemeralPamDatabaseModel struct {
 	ProviderRegion types.String `tfsdk:"provider_region"`
 	FileRef        types.List   `tfsdk:"file_ref"`
 	TOTP           types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom         types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamDatabase() ephemeral.EphemeralResource {
@@ -199,7 +199,6 @@ func (e *ephemeralPamDatabase) Open(ctx context.Context, req ephemeral.OpenReque
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_database_test.go
+++ b/secretsmanager/ephemeral_pam_database_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUpamUdatabase(t *testing.T) {
 	secretType := "pamDatabase"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_pam_directory.go
+++ b/secretsmanager/ephemeral_pam_directory.go
@@ -37,7 +37,7 @@ type ephemeralPamDirectoryModel struct {
 	AlternativeIPs    types.String `tfsdk:"alternative_ips"`
 	FileRef           types.List   `tfsdk:"file_ref"`
 	TOTP              types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom            types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamDirectory() ephemeral.EphemeralResource {
@@ -223,7 +223,6 @@ func (e *ephemeralPamDirectory) Open(ctx context.Context, req ephemeral.OpenRequ
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_directory_test.go
+++ b/secretsmanager/ephemeral_pam_directory_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUpamUdirectory(t *testing.T) {
 	secretType := "pamDirectory"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_pam_machine.go
+++ b/secretsmanager/ephemeral_pam_machine.go
@@ -38,7 +38,7 @@ type ephemeralPamMachineModel struct {
 	ProviderRegion       types.String `tfsdk:"provider_region"`
 	FileRef              types.List   `tfsdk:"file_ref"`
 	TOTP                 types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom               types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamMachine() ephemeral.EphemeralResource {
@@ -232,7 +232,6 @@ func (e *ephemeralPamMachine) Open(ctx context.Context, req ephemeral.OpenReques
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_machine_test.go
+++ b/secretsmanager/ephemeral_pam_machine_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUpamUmachine(t *testing.T) {
 	secretType := "pamMachine"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_pam_remote_browser.go
+++ b/secretsmanager/ephemeral_pam_remote_browser.go
@@ -19,17 +19,17 @@ type ephemeralPamRemoteBrowser struct {
 }
 
 type ephemeralPamRemoteBrowserModel struct {
-	Path                      types.String `tfsdk:"path"`
-	Type                      types.String `tfsdk:"type"`
-	Title                     types.String `tfsdk:"title"`
-	Notes                     types.String `tfsdk:"notes"`
-	FolderUID                 types.String `tfsdk:"folder_uid"`
-	RbiUrl                    types.String `tfsdk:"rbi_url"`
-	PamRemoteBrowserSettings  types.String `tfsdk:"pam_remote_browser_settings"`
-	TrafficEncryptionSeed     types.String `tfsdk:"traffic_encryption_seed"`
-	FileRef                   types.List   `tfsdk:"file_ref"`
-	TOTP                      types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Path                     types.String `tfsdk:"path"`
+	Type                     types.String `tfsdk:"type"`
+	Title                    types.String `tfsdk:"title"`
+	Notes                    types.String `tfsdk:"notes"`
+	FolderUID                types.String `tfsdk:"folder_uid"`
+	RbiUrl                   types.String `tfsdk:"rbi_url"`
+	PamRemoteBrowserSettings types.String `tfsdk:"pam_remote_browser_settings"`
+	TrafficEncryptionSeed    types.String `tfsdk:"traffic_encryption_seed"`
+	FileRef                  types.List   `tfsdk:"file_ref"`
+	TOTP                     types.List   `tfsdk:"totp"`
+	Custom                   types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamRemoteBrowser() ephemeral.EphemeralResource {
@@ -191,7 +191,6 @@ func (e *ephemeralPamRemoteBrowser) Open(ctx context.Context, req ephemeral.Open
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_remote_browser_test.go
+++ b/secretsmanager/ephemeral_pam_remote_browser_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUpamUremoteUbrowser(t *testing.T) {
 	secretType := "pamRemoteBrowser"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_pam_user.go
+++ b/secretsmanager/ephemeral_pam_user.go
@@ -33,7 +33,7 @@ type ephemeralPamUserModel struct {
 	Managed              types.Bool   `tfsdk:"managed"`
 	FileRef              types.List   `tfsdk:"file_ref"`
 	TOTP                 types.List   `tfsdk:"totp"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom               types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPamUser() ephemeral.EphemeralResource {
@@ -202,7 +202,6 @@ func (e *ephemeralPamUser) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_pam_user_test.go
+++ b/secretsmanager/ephemeral_pam_user_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUpamUuser(t *testing.T) {
 	secretType := "pamUser"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_passport.go
+++ b/secretsmanager/ephemeral_passport.go
@@ -31,7 +31,7 @@ type ephemeralPassportModel struct {
 	Password       types.String `tfsdk:"password"`
 	AddressRef     types.List   `tfsdk:"address_ref"`
 	FileRef        types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom         types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralPassport() ephemeral.EphemeralResource {
@@ -87,7 +87,7 @@ func (e *ephemeralPassport) Schema(_ context.Context, _ ephemeral.SchemaRequest,
 			},
 			"address_ref": addressRefEphemeralAttribute(),
 			"file_ref":    fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":      genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -161,7 +161,6 @@ func (e *ephemeralPassport) Open(ctx context.Context, req ephemeral.OpenRequest,
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_passport_test.go
+++ b/secretsmanager/ephemeral_passport_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUpassport(t *testing.T) {
 	secretType := "passport"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_photo.go
+++ b/secretsmanager/ephemeral_photo.go
@@ -57,7 +57,7 @@ func (e *ephemeralPhoto) Schema(_ context.Context, _ ephemeral.SchemaRequest, re
 				Description: "The secret notes.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -118,7 +118,6 @@ func (e *ephemeralPhoto) Open(ctx context.Context, req ephemeral.OpenRequest, re
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_photo_test.go
+++ b/secretsmanager/ephemeral_photo_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUphoto(t *testing.T) {
 	secretType := "photo"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_record.go
+++ b/secretsmanager/ephemeral_record.go
@@ -59,8 +59,8 @@ func (e *ephemeralRecord) Schema(_ context.Context, _ ephemeral.SchemaRequest, r
 				Computed:    true,
 				Description: "The secret notes.",
 			},
-			"fields": genericFieldEphemeralAttribute("Standard fields of the record."),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"fields":   genericFieldEphemeralAttribute("Standard fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 			"file_ref": fileRefEphemeralAttribute(),
 		},
 	}

--- a/secretsmanager/ephemeral_record_test.go
+++ b/secretsmanager/ephemeral_record_test.go
@@ -12,7 +12,7 @@ func TestAccEphemeralRecord(t *testing.T) {
 	secretType := "login"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`
@@ -37,7 +37,7 @@ func TestAccEphemeralRecordByTitle(t *testing.T) {
 	secretType := "login"
 	_, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_server_credentials.go
+++ b/secretsmanager/ephemeral_server_credentials.go
@@ -27,7 +27,7 @@ type ephemeralServerCredentialsModel struct {
 	Login    types.String `tfsdk:"login"`
 	Password types.String `tfsdk:"password"`
 	FileRef  types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom   types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralServerCredentials() ephemeral.EphemeralResource {
@@ -70,7 +70,7 @@ func (e *ephemeralServerCredentials) Schema(_ context.Context, _ ephemeral.Schem
 			},
 			"host":     hostEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -137,7 +137,6 @@ func (e *ephemeralServerCredentials) Open(ctx context.Context, req ephemeral.Ope
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_server_credentials_test.go
+++ b/secretsmanager/ephemeral_server_credentials_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUserverUcredentials(t *testing.T) {
 	secretType := "serverCredentials"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_software_license.go
+++ b/secretsmanager/ephemeral_software_license.go
@@ -27,7 +27,7 @@ type ephemeralSoftwareLicenseModel struct {
 	ActivationDate types.String `tfsdk:"activation_date"`
 	ExpirationDate types.String `tfsdk:"expiration_date"`
 	FileRef        types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom         types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralSoftwareLicense() ephemeral.EphemeralResource {
@@ -72,7 +72,7 @@ func (e *ephemeralSoftwareLicense) Schema(_ context.Context, _ ephemeral.SchemaR
 				Description: "Date of expiration.",
 			},
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -137,7 +137,6 @@ func (e *ephemeralSoftwareLicense) Open(ctx context.Context, req ephemeral.OpenR
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_software_license_test.go
+++ b/secretsmanager/ephemeral_software_license_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUsoftwareUlicense(t *testing.T) {
 	secretType := "softwareLicense"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_ssh_keys.go
+++ b/secretsmanager/ephemeral_ssh_keys.go
@@ -28,7 +28,7 @@ type ephemeralSshKeysModel struct {
 	Passphrase types.String `tfsdk:"passphrase"`
 	Host       types.List   `tfsdk:"host"`
 	FileRef    types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom     types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralSshKeys() ephemeral.EphemeralResource {
@@ -88,7 +88,7 @@ func (e *ephemeralSshKeys) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			},
 			"host":     hostEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -159,7 +159,6 @@ func (e *ephemeralSshKeys) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_ssh_keys_test.go
+++ b/secretsmanager/ephemeral_ssh_keys_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUsshUkeys(t *testing.T) {
 	secretType := "sshKeys"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/ephemeral_ssn_card.go
+++ b/secretsmanager/ephemeral_ssn_card.go
@@ -26,7 +26,7 @@ type ephemeralSsnCardModel struct {
 	IdentityNumber types.String `tfsdk:"identity_number"`
 	Name           types.List   `tfsdk:"name"`
 	FileRef        types.List   `tfsdk:"file_ref"`
-	Custom  types.List   `tfsdk:"custom"`
+	Custom         types.List   `tfsdk:"custom"`
 }
 
 func NewEphemeralSsnCard() ephemeral.EphemeralResource {
@@ -64,7 +64,7 @@ func (e *ephemeralSsnCard) Schema(_ context.Context, _ ephemeral.SchemaRequest, 
 			},
 			"name":     nameEphemeralAttribute(),
 			"file_ref": fileRefEphemeralAttribute(),
-			"custom": genericFieldEphemeralAttribute("Custom fields of the record."),
+			"custom":   genericFieldEphemeralAttribute("Custom fields of the record."),
 		},
 	}
 }
@@ -130,7 +130,6 @@ func (e *ephemeralSsnCard) Open(ctx context.Context, req ephemeral.OpenRequest, 
 	customList, diags := genericFieldItemsToListValue(ctx, customItems)
 	resp.Diagnostics.Append(diags...)
 	data.Custom = customList
-
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/secretsmanager/ephemeral_ssn_card_test.go
+++ b/secretsmanager/ephemeral_ssn_card_test.go
@@ -11,7 +11,7 @@ func TestAccEphemeralUssnUcard(t *testing.T) {
 	secretType := "ssnCard"
 	secretUid, secretTitle := testAcc.getRecordInfo(secretType)
 	if secretUid == "" || secretTitle == "" {
-		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+		t.Skip("Skipping test - TF_ACC not set or test data not configured")
 	}
 
 	config := fmt.Sprintf(`

--- a/secretsmanager/fwprovider.go
+++ b/secretsmanager/fwprovider.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	_ provider.Provider                        = &fwProvider{}
-	_ provider.ProviderWithEphemeralResources  = &fwProvider{}
+	_ provider.Provider                       = &fwProvider{}
+	_ provider.ProviderWithEphemeralResources = &fwProvider{}
 )
 
 // fwProvider is the Plugin Framework provider that serves ephemeral resources.

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -371,33 +371,33 @@ func parseJSONItems(value string) ([]json.RawMessage, error) {
 // case-insensitive user input while preserving the casing the KSM vault
 // expects when storing fields.
 var customFieldTypeCanonical = map[string]string{
-	"text":                "text",
-	"multiline":           "multiline",
-	"secret":              "secret",
-	"url":                 "url",
-	"email":               "email",
-	"login":               "login",
-	"password":            "password",
-	"pincode":             "pinCode",
-	"accountnumber":       "accountNumber",
-	"licensenumber":       "licenseNumber",
-	"checkbox":            "checkbox",
-	"date":                "date",
-	"birthdate":           "birthDate",
-	"expirationdate":      "expirationDate",
-	"phone":               "phone",
-	"name":                "name",
-	"address":             "address",
-	"paymentcard":         "paymentCard",
-	"bankaccount":         "bankAccount",
-	"host":                "host",
-	"securityquestion":    "securityQuestion",
-	"keypair":             "keyPair",
-	"script":              "script",
-	"addressref":          "addressRef",
-	"cardref":             "cardRef",
-	"fileref":             "fileRef",
-	"onetimecode":         "oneTimeCode",
+	"text":             "text",
+	"multiline":        "multiline",
+	"secret":           "secret",
+	"url":              "url",
+	"email":            "email",
+	"login":            "login",
+	"password":         "password",
+	"pincode":          "pinCode",
+	"accountnumber":    "accountNumber",
+	"licensenumber":    "licenseNumber",
+	"checkbox":         "checkbox",
+	"date":             "date",
+	"birthdate":        "birthDate",
+	"expirationdate":   "expirationDate",
+	"phone":            "phone",
+	"name":             "name",
+	"address":          "address",
+	"paymentcard":      "paymentCard",
+	"bankaccount":      "bankAccount",
+	"host":             "host",
+	"securityquestion": "securityQuestion",
+	"keypair":          "keyPair",
+	"script":           "script",
+	"addressref":       "addressRef",
+	"cardref":          "cardRef",
+	"fileref":          "fileRef",
+	"onetimecode":      "oneTimeCode",
 }
 
 // customFieldsFromSchema converts the "custom" TypeList from schema into a slice of
@@ -481,10 +481,18 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for phone entry: %w", label, err)
 					}
 					phone := core.Phone{}
-					if s, ok := v["region"].(string); ok { phone.Region = s }
-					if s, ok := v["number"].(string); ok { phone.Number = s }
-					if s, ok := v["ext"].(string); ok { phone.Ext = s }
-					if s, ok := v["type"].(string); ok { phone.Type = s }
+					if s, ok := v["region"].(string); ok {
+						phone.Region = s
+					}
+					if s, ok := v["number"].(string); ok {
+						phone.Number = s
+					}
+					if s, ok := v["ext"].(string); ok {
+						phone.Ext = s
+					}
+					if s, ok := v["type"].(string); ok {
+						phone.Type = s
+					}
 					f.Value = append(f.Value, phone)
 				}
 			}
@@ -503,9 +511,15 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for name entry: %w", label, err)
 					}
 					name := core.Name{}
-					if s, ok := v["first"].(string); ok { name.First = s }
-					if s, ok := v["middle"].(string); ok { name.Middle = s }
-					if s, ok := v["last"].(string); ok { name.Last = s }
+					if s, ok := v["first"].(string); ok {
+						name.First = s
+					}
+					if s, ok := v["middle"].(string); ok {
+						name.Middle = s
+					}
+					if s, ok := v["last"].(string); ok {
+						name.Last = s
+					}
 					f.Value = append(f.Value, name)
 				}
 			}
@@ -524,12 +538,24 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for address entry: %w", label, err)
 					}
 					addr := core.Address{}
-					if s, ok := v["street1"].(string); ok { addr.Street1 = s }
-					if s, ok := v["street2"].(string); ok { addr.Street2 = s }
-					if s, ok := v["city"].(string); ok { addr.City = s }
-					if s, ok := v["state"].(string); ok { addr.State = s }
-					if s, ok := v["country"].(string); ok { addr.Country = s }
-					if s, ok := v["zip"].(string); ok { addr.Zip = s }
+					if s, ok := v["street1"].(string); ok {
+						addr.Street1 = s
+					}
+					if s, ok := v["street2"].(string); ok {
+						addr.Street2 = s
+					}
+					if s, ok := v["city"].(string); ok {
+						addr.City = s
+					}
+					if s, ok := v["state"].(string); ok {
+						addr.State = s
+					}
+					if s, ok := v["country"].(string); ok {
+						addr.Country = s
+					}
+					if s, ok := v["zip"].(string); ok {
+						addr.Zip = s
+					}
 					f.Value = append(f.Value, addr)
 				}
 			}
@@ -548,9 +574,15 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for paymentCard entry: %w", label, err)
 					}
 					card := core.PaymentCard{}
-					if s, ok := v["cardNumber"].(string); ok { card.CardNumber = s }
-					if s, ok := v["cardExpirationDate"].(string); ok { card.CardExpirationDate = s }
-					if s, ok := v["cardSecurityCode"].(string); ok { card.CardSecurityCode = s }
+					if s, ok := v["cardNumber"].(string); ok {
+						card.CardNumber = s
+					}
+					if s, ok := v["cardExpirationDate"].(string); ok {
+						card.CardExpirationDate = s
+					}
+					if s, ok := v["cardSecurityCode"].(string); ok {
+						card.CardSecurityCode = s
+					}
 					f.Value = append(f.Value, card)
 				}
 			}
@@ -569,10 +601,18 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for bankAccount entry: %w", label, err)
 					}
 					acct := core.BankAccount{}
-					if s, ok := v["accountType"].(string); ok { acct.AccountType = s }
-					if s, ok := v["routingNumber"].(string); ok { acct.RoutingNumber = s }
-					if s, ok := v["accountNumber"].(string); ok { acct.AccountNumber = s }
-					if s, ok := v["otherType"].(string); ok { acct.OtherType = s }
+					if s, ok := v["accountType"].(string); ok {
+						acct.AccountType = s
+					}
+					if s, ok := v["routingNumber"].(string); ok {
+						acct.RoutingNumber = s
+					}
+					if s, ok := v["accountNumber"].(string); ok {
+						acct.AccountNumber = s
+					}
+					if s, ok := v["otherType"].(string); ok {
+						acct.OtherType = s
+					}
 					f.Value = append(f.Value, acct)
 				}
 			}
@@ -591,8 +631,12 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for host entry: %w", label, err)
 					}
 					h := core.Host{}
-					if s, ok := v["hostName"].(string); ok { h.Hostname = s }
-					if s, ok := v["port"].(string); ok { h.Port = s }
+					if s, ok := v["hostName"].(string); ok {
+						h.Hostname = s
+					}
+					if s, ok := v["port"].(string); ok {
+						h.Port = s
+					}
 					f.Value = append(f.Value, h)
 				}
 			}
@@ -611,8 +655,12 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for securityQuestion entry: %w", label, err)
 					}
 					q := core.SecurityQuestion{}
-					if s, ok := v["question"].(string); ok { q.Question = s }
-					if s, ok := v["answer"].(string); ok { q.Answer = s }
+					if s, ok := v["question"].(string); ok {
+						q.Question = s
+					}
+					if s, ok := v["answer"].(string); ok {
+						q.Answer = s
+					}
 					f.Value = append(f.Value, q)
 				}
 			}
@@ -631,8 +679,12 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for keyPair entry: %w", label, err)
 					}
 					kp := core.KeyPair{}
-					if s, ok := v["publicKey"].(string); ok { kp.PublicKey = s }
-					if s, ok := v["privateKey"].(string); ok { kp.PrivateKey = s }
+					if s, ok := v["publicKey"].(string); ok {
+						kp.PublicKey = s
+					}
+					if s, ok := v["privateKey"].(string); ok {
+						kp.PrivateKey = s
+					}
 					f.Value = append(f.Value, kp)
 				}
 			}
@@ -651,8 +703,12 @@ func customFieldsFromSchema(items []interface{}) ([]interface{}, error) {
 						return nil, fmt.Errorf("custom field %q: invalid JSON for script entry: %w", label, err)
 					}
 					s := core.Script{}
-					if str, ok := v["fileRef"].(string); ok { s.FileRef = str }
-					if str, ok := v["command"].(string); ok { s.Command = str }
+					if str, ok := v["fileRef"].(string); ok {
+						s.FileRef = str
+					}
+					if str, ok := v["command"].(string); ok {
+						s.Command = str
+					}
 					if arr, ok := v["recordRef"].([]interface{}); ok {
 						for _, r := range arr {
 							if str, ok := r.(string); ok {

--- a/secretsmanager/provider_test.go
+++ b/secretsmanager/provider_test.go
@@ -159,12 +159,12 @@ func TestValidatePamCustomFieldLabels(t *testing.T) {
 		label   string
 		wantErr bool
 	}{
-		{"Private Key Passphrase", true},  // exact canonical — blocked
-		{"private key passphrase", true},  // all lowercase — now blocked
-		{"PRIVATE KEY PASSPHRASE", true},  // all uppercase — now blocked
-		{"Private Key PASSPHRASE", true},  // mixed case — now blocked
-		{"Owner", false},                  // non-reserved — allowed
-		{"", false},                       // empty — allowed
+		{"Private Key Passphrase", true}, // exact canonical — blocked
+		{"private key passphrase", true}, // all lowercase — now blocked
+		{"PRIVATE KEY PASSPHRASE", true}, // all uppercase — now blocked
+		{"Private Key PASSPHRASE", true}, // mixed case — now blocked
+		{"Owner", false},                 // non-reserved — allowed
+		{"", false},                      // empty — allowed
 	}
 	for _, tc := range cases {
 		items := []interface{}{

--- a/secretsmanager/resource_address_test.go
+++ b/secretsmanager/resource_address_test.go
@@ -44,7 +44,7 @@ func TestAccResourceAddress_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_address.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -92,7 +92,7 @@ func TestAccResourceAddress_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -142,7 +142,7 @@ func TestAccResourceAddress_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -185,7 +185,7 @@ func TestAccResourceAddress_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_address.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_bank_account_test.go
+++ b/secretsmanager/resource_bank_account_test.go
@@ -91,7 +91,7 @@ func TestAccResourceBankAccount_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_bank_account.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -139,7 +139,7 @@ func TestAccResourceBankAccount_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -189,7 +189,7 @@ func TestAccResourceBankAccount_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -232,7 +232,7 @@ func TestAccResourceBankAccount_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_bank_account.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_bank_card_test.go
+++ b/secretsmanager/resource_bank_card_test.go
@@ -59,7 +59,7 @@ func TestAccResourceBankCard_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_bank_card.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -107,7 +107,7 @@ func TestAccResourceBankCard_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -157,7 +157,7 @@ func TestAccResourceBankCard_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -200,7 +200,7 @@ func TestAccResourceBankCard_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_bank_card.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_birth_certificate_test.go
+++ b/secretsmanager/resource_birth_certificate_test.go
@@ -47,7 +47,7 @@ func TestAccResourceBirthCertificate_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_birth_certificate.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -95,7 +95,7 @@ func TestAccResourceBirthCertificate_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -145,7 +145,7 @@ func TestAccResourceBirthCertificate_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -188,7 +188,7 @@ func TestAccResourceBirthCertificate_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_birth_certificate.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_contact_test.go
+++ b/secretsmanager/resource_contact_test.go
@@ -70,7 +70,7 @@ func TestAccResourceContact_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_contact.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -118,7 +118,7 @@ func TestAccResourceContact_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -168,7 +168,7 @@ func TestAccResourceContact_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -211,7 +211,7 @@ func TestAccResourceContact_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_contact.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_database_credentials_test.go
+++ b/secretsmanager/resource_database_credentials_test.go
@@ -67,7 +67,7 @@ func TestAccResourceDatabaseCredentials_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_database_credentials.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -115,7 +115,7 @@ func TestAccResourceDatabaseCredentials_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -165,7 +165,7 @@ func TestAccResourceDatabaseCredentials_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -208,7 +208,7 @@ func TestAccResourceDatabaseCredentials_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_database_credentials.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_driver_license_test.go
+++ b/secretsmanager/resource_driver_license_test.go
@@ -65,7 +65,7 @@ func TestAccResourceDriverLicense_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_driver_license.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -113,7 +113,7 @@ func TestAccResourceDriverLicense_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -163,7 +163,7 @@ func TestAccResourceDriverLicense_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -206,7 +206,7 @@ func TestAccResourceDriverLicense_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_driver_license.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_encrypted_notes_test.go
+++ b/secretsmanager/resource_encrypted_notes_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/keeper-security/secrets-manager-go/core"
 )
 
-
 func TestAccResourceEncryptedNotes_create(t *testing.T) {
 	secretType := "encryptedNotes"
 	secretFolderUid := testAcc.getTestFolder()
@@ -44,7 +43,7 @@ func TestAccResourceEncryptedNotes_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_encrypted_notes.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -92,7 +91,7 @@ func TestAccResourceEncryptedNotes_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -142,7 +141,7 @@ func TestAccResourceEncryptedNotes_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -185,7 +184,7 @@ func TestAccResourceEncryptedNotes_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_encrypted_notes.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_file_test.go
+++ b/secretsmanager/resource_file_test.go
@@ -35,7 +35,7 @@ func TestAccResourceFile_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_file.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -83,7 +83,7 @@ func TestAccResourceFile_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -133,7 +133,7 @@ func TestAccResourceFile_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -176,7 +176,7 @@ func TestAccResourceFile_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_file.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_folder_test.go
+++ b/secretsmanager/resource_folder_test.go
@@ -23,7 +23,7 @@ func TestAccResourceFolder_create(t *testing.T) {
 	}`, secretTitle, testFolderUid, secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -58,7 +58,7 @@ func TestAccResourceFolder_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -102,7 +102,7 @@ func TestAccResourceFolder_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -140,7 +140,7 @@ func TestAccResourceFolder_import(t *testing.T) {
 	}`, secretTitle, testFolderUid, secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_health_insurance_test.go
+++ b/secretsmanager/resource_health_insurance_test.go
@@ -74,7 +74,7 @@ func TestAccResourceHealthInsurance_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_health_insurance.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -122,7 +122,7 @@ func TestAccResourceHealthInsurance_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -172,7 +172,7 @@ func TestAccResourceHealthInsurance_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -215,7 +215,7 @@ func TestAccResourceHealthInsurance_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_health_insurance.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_membership_test.go
+++ b/secretsmanager/resource_membership_test.go
@@ -62,7 +62,7 @@ func TestAccResourceMembership_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_membership.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -110,7 +110,7 @@ func TestAccResourceMembership_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -160,7 +160,7 @@ func TestAccResourceMembership_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -203,7 +203,7 @@ func TestAccResourceMembership_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_membership.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_pam_database_test.go
+++ b/secretsmanager/resource_pam_database_test.go
@@ -48,7 +48,7 @@ func TestAccResourcePamDatabase_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_database.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -130,7 +130,7 @@ func TestAccResourcePamDatabase_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -193,7 +193,7 @@ func TestAccResourcePamDatabase_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -234,7 +234,7 @@ func TestAccResourcePamDatabase_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_database.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_pam_directory_test.go
+++ b/secretsmanager/resource_pam_directory_test.go
@@ -74,7 +74,7 @@ func TestAccResourcePamDirectory_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_directory.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -160,7 +160,7 @@ func TestAccResourcePamDirectory_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -219,7 +219,7 @@ func TestAccResourcePamDirectory_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -267,7 +267,7 @@ func TestAccResourcePamDirectory_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_directory.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_pam_machine_test.go
+++ b/secretsmanager/resource_pam_machine_test.go
@@ -49,7 +49,7 @@ func TestAccResourcePamMachine_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_machine.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -90,7 +90,7 @@ func TestAccResourcePamMachine_create_no_uid(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_machine.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -164,7 +164,7 @@ func TestAccResourcePamMachine_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -223,7 +223,7 @@ func TestAccResourcePamMachine_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -264,7 +264,7 @@ func TestAccResourcePamMachine_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_machine.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -308,7 +308,7 @@ func TestAccResourcePamMachine_generatePrivatePemKey(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_machine.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -465,7 +465,7 @@ func TestAccResourcePamMachine_generatePrivatePemKeyWithPassphrase(t *testing.T)
 	resourceName := fmt.Sprintf("secretsmanager_pam_machine.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/resource_pam_remote_browser.go
+++ b/secretsmanager/resource_pam_remote_browser.go
@@ -54,7 +54,7 @@ func resourcePamRemoteBrowser() *schema.Resource {
 				Description: "The secret notes.",
 			},
 			// PAM Remote Browser specific fields
-			"rbi_url":                 schemaTextField(),
+			"rbi_url": schemaTextField(),
 			"pam_remote_browser_settings": {
 				Type:             schema.TypeString,
 				Optional:         true,

--- a/secretsmanager/resource_pam_remote_browser_test.go
+++ b/secretsmanager/resource_pam_remote_browser_test.go
@@ -32,7 +32,7 @@ func TestAccResourcePamRemoteBrowser_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_remote_browser.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -67,7 +67,7 @@ func TestAccResourcePamRemoteBrowser_create_no_uid(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_remote_browser.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -103,7 +103,7 @@ func TestAccResourcePamRemoteBrowser_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_remote_browser.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -113,8 +113,8 @@ func TestAccResourcePamRemoteBrowser_import(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportState:        true,
-				ImportStateVerify:  true,
+				ImportState:       true,
+				ImportStateVerify: true,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					return secretUid, nil
 				},

--- a/secretsmanager/resource_pam_user_test.go
+++ b/secretsmanager/resource_pam_user_test.go
@@ -58,7 +58,7 @@ func TestAccResourcePamUser_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_user.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -119,7 +119,7 @@ func TestAccResourcePamUser_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -167,7 +167,7 @@ func TestAccResourcePamUser_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -211,7 +211,7 @@ func TestAccResourcePamUser_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_user.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -252,7 +252,7 @@ func TestAccResourcePamUser_generatePrivatePemKey(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_user.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -316,7 +316,7 @@ func TestAccResourcePamUser_generatePrivatePemKeyWithPassphrase(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_pam_user.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/secretsmanager/resource_passport_test.go
+++ b/secretsmanager/resource_passport_test.go
@@ -86,7 +86,7 @@ func TestAccResourcePassport_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_passport.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -134,7 +134,7 @@ func TestAccResourcePassport_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -184,7 +184,7 @@ func TestAccResourcePassport_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -227,7 +227,7 @@ func TestAccResourcePassport_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_passport.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_photo_test.go
+++ b/secretsmanager/resource_photo_test.go
@@ -35,7 +35,7 @@ func TestAccResourcePhoto_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_photo.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -83,7 +83,7 @@ func TestAccResourcePhoto_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -133,7 +133,7 @@ func TestAccResourcePhoto_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -176,7 +176,7 @@ func TestAccResourcePhoto_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_photo.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_server_credentials_test.go
+++ b/secretsmanager/resource_server_credentials_test.go
@@ -61,7 +61,7 @@ func TestAccResourceServerCredentials_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_server_credentials.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -109,7 +109,7 @@ func TestAccResourceServerCredentials_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -159,7 +159,7 @@ func TestAccResourceServerCredentials_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -202,7 +202,7 @@ func TestAccResourceServerCredentials_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_server_credentials.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_software_license_test.go
+++ b/secretsmanager/resource_software_license_test.go
@@ -49,7 +49,7 @@ func TestAccResourceSoftwareLicense_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_software_license.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -97,7 +97,7 @@ func TestAccResourceSoftwareLicense_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -147,7 +147,7 @@ func TestAccResourceSoftwareLicense_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -190,7 +190,7 @@ func TestAccResourceSoftwareLicense_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_software_license.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_ssh_keys_test.go
+++ b/secretsmanager/resource_ssh_keys_test.go
@@ -70,7 +70,7 @@ func TestAccResourceSshKeys_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_ssh_keys.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -111,7 +111,7 @@ func TestAccResourceSshKeys_generateED25519(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_ssh_keys.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -176,7 +176,7 @@ func TestAccResourceSshKeys_generateWithPassphrase(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_ssh_keys.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -237,7 +237,7 @@ func TestAccResourceSshKeys_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -287,7 +287,7 @@ func TestAccResourceSshKeys_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -330,7 +330,7 @@ func TestAccResourceSshKeys_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_ssh_keys.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/secretsmanager/resource_ssn_card_test.go
+++ b/secretsmanager/resource_ssn_card_test.go
@@ -47,7 +47,7 @@ func TestAccResourceSsnCard_create(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_ssn_card.%v", secretTitle)
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -95,7 +95,7 @@ func TestAccResourceSsnCard_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: configInit,
@@ -145,7 +145,7 @@ func TestAccResourceSsnCard_deleteDetection(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -188,7 +188,7 @@ func TestAccResourceSsnCard_import(t *testing.T) {
 	resourceName := fmt.Sprintf("secretsmanager_ssn_card.%v", secretTitle)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  testAccPreCheck(t),
+		PreCheck:                 testAccPreCheck(t),
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
## Summary

The `Test-Terraform-Provider` workflow has never run on a pull request. Its `pull_request` trigger filtered on `branches: [ main ]`, but a `main` branch has never existed in this repo: the default branch is `master` and feature work flows through `release-*` branches. The filter matched nothing, so the build / vet / gofmt / unit-test gate was silently skipped on every PR since the workflow was introduced in v1.2.0. Only CodeQL and Socket ran, which is why this went unnoticed (KSM-1028).

This points the trigger at `master` and `release-**`, so both release-to-master PRs and feature-to-release PRs are now gated. The acceptance-test suite is unaffected: it stays excluded from this workflow (it needs live credentials) and is unchanged.

Because the gate never ran, the package was not gofmt-clean. The mechanical `gofmt -s -w` pass is isolated in its own commit so the one-line trigger change is reviewable on its own; `git show --stat` confirms it is pure formatting with no logic changes.

## Breaking Changes

None.