### PR TITLE
fix(deps): bump Go toolchain to 1.26.7 for CVE-2026-39821 (KSM-1246)

### DIFF
--- a/.github/workflows/scan.govulncheck.yml
+++ b/.github/workflows/scan.govulncheck.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           check-latest: true
 
       - name: Install govulncheck

--- a/.github/workflows/terraform-provider-release-process.yml
+++ b/.github/workflows/terraform-provider-release-process.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           check-latest: true
 
       - name: Generate SBOM
@@ -220,7 +220,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false
 
       - name: Import GPG key

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test-terraform-provider:
     strategy:
       matrix:
-        go-version: [ '1.26.5' ]
+        go-version: [ '1.26.7' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     name: Test with Go ${{ matrix.go-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.4.0]
 
+### Security
+- Build with Go 1.26.7, up from 1.26.2, clearing the standard library half of CVE-2026-39821 (Punycode-encoded label handling reachable through `net/http`) plus seven further stdlib advisories reported against the earlier 1.26.x patches (KSM-1246)
+- Bump `golang.org/x/net` to v0.57.0 from v0.48.0, clearing the `golang.org/x/net/idna` half of CVE-2026-39821 (KSM-1246)
+- Bump `golang.org/x/crypto` to v0.54.0 from v0.46.0, closing 13 advisories
+- Bump `google.golang.org/grpc` to v1.82.1 from v1.79.3, closing GHSA-hrxh-6v49-42gf
+
 ### Fixed
 - Fix `special=0` being ignored when password `length` exceeds the sum of category counts (KSM-989)
 - Clarify that `caps`, `lowercase`, `digits`, and `special` in the `complexity` block are minimum counts, not exact targets — the generator may produce more of each character class to satisfy the total `length` (KSM-1071)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keeper-security/terraform-provider-secretsmanager
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/hashicorp/go-cty v1.5.0


### PR DESCRIPTION
## Summary

KSM-1246 asks for two things in this repo: `golang.org/x/net` at 0.55.0 or newer, and a build on a Go toolchain patched for CVE-2026-39821 (1.25.13, 1.26.6, or 1.27.0-rc.3).

The x/net half was already satisfied. #90 carries x/net v0.57.0 via a29ea9b, a Dependabot cleanup that landed 2026-07-20, three weeks before KSM-1246 was filed. The toolchain half was not: the release branch is pinned at **1.26.5**, one patch below the 1.26.6 fix.

## Why the green govulncheck check on #90 did not catch this

`scan.govulncheck.yml` uploads SARIF to code scanning and writes a step summary. It never fails the job on findings. That is deliberate and documented in the workflow header, but it does mean a green check is evidence the job ran, not that the scan came back clean.

It also triggers only on `pull_request: branches: [ master ]`, so it will not run on this PR either. This was verified locally with the same tool pin CI uses, `govulncheck@v1.6.0`: 6 reachable stdlib vulnerabilities on 1.26.5, 0 on 1.26.7.

## Scope of the finding

CVE-2026-39821 / GO-2026-5026 has two halves: `golang.org/x/net/idna` (fixed in x/net 0.55.0) and the idna copy vendored into the `net/http` standard library (fixed in Go 1.26.6).

Scanning the provider binary built on 1.26.5 turned up six stdlib advisories with live call paths, not one:

| Advisory | Package | Reachability |
| --- | --- | --- |
| GO-2026-5026 (CVE-2026-39821) | `net/http` | called, via `http.Client.Do` / `http.Client.Get` |
| GO-2026-5942 | `net` | called, via `net.Resolver.LookupCNAME` |
| GO-2026-5972 | `encoding/asn1` | called, via `asn1.Unmarshal` |
| GO-2026-6090 | `crypto/tls` | called, via `tls.Conn.Handshake` |
| GO-2026-6091 | `html/template` | called, via `template.Template.Execute` |
| GO-2026-6218 | `net/url` | called |
| GO-2026-6089 | `net/http` | imported, not called |
| GO-2026-6088 | `stdlib` | module level |

All eight are fixed in 1.26.6.

## Changes

* `go.mod`: `go` directive from 1.26.5 to 1.26.7.
* `.github/workflows/test.yml`, `.github/workflows/scan.govulncheck.yml`, and `.github/workflows/terraform-provider-release-process.yml` (both the SBOM job and the GoReleaser job): `go-version` pins from 1.26.5 to 1.26.7. `scan.govulncheck.yml` requires these to stay in step so stdlib findings reflect the build we actually ship.
* `CHANGELOG.md`: adds a Security section to 1.4.0. Four security bumps (toolchain, x/net, x/crypto, grpc) landed on this release branch without changelog entries, so the v1.4.0 notes would have shipped with no mention of the CVE remediation. 1.2.0 and 1.3.0 both carry a Security section.

### Why 1.26.7 rather than 1.27.0

1.27.0 went stable on 2026-08-18 and would also satisfy the ticket, but moving a release branch that has already been through QA onto a new minor version is not a trade worth making for a standard library patch. 1.26.7 is the latest patch on the line already in use and clears every currently known stdlib advisory. It also matches the precedent set by d08e897, which took the latest patch available at the time rather than the bare minimum.

One residual finding, unchanged by this PR: GO-2026-5932, `golang.org/x/crypto/openpgp` is unmaintained and unsafe by design. It reports `Fixed in: N/A`, so no version bump resolves it, and there is no call path to it from this provider.

A useful side effect of raising the `go` directive: a 1.26.5 build is now refused outright rather than silently producing a vulnerable binary.

## Related

* KSM-1246, REL-4790
* VM-3267, the Manifest scan the finding came from
* Targets `release-v1.4.0` so #90 picks this up before the release is cut.

