### PR TITLE
docs(complexity): complete KSM-1071 minimums fix and document special_set (KSM-990)

### DIFF
--- a/docs/data-sources/record.md
+++ b/docs/data-sources/record.md
@@ -29,10 +29,11 @@ In addition to all arguments above, the following attributes are exported:
   - `enforce_generation` - Enforce generation flag (for password field)
   - `complexity` - A list containing password complexity information
     - `length` - Minimum Password length.
-    - `caps` Number of uppercase characters.
-    - `lowercase` Number of lowercase characters.
-    - `digits` Number of digits.
-    - `special` Number of special characters.
+    - `caps` Minimum number of uppercase characters.
+    - `lowercase` Minimum number of lowercase characters.
+    - `digits` Minimum number of digits.
+    - `special` Minimum number of special characters.
+    - Counts are minimums, not exact targets: when `length` exceeds their sum, the generator draws the remainder from all enabled character classes.
   - `value` - Field value
 * `custom` - A list containing custom fields information:
   - `type` - Field type
@@ -42,10 +43,11 @@ In addition to all arguments above, the following attributes are exported:
   - `enforce_generation` - Enforce generation flag (for password field)
   - `complexity` - A list containing password complexity information
     - `length` - Minimum Password length.
-    - `caps` Number of uppercase characters.
-    - `lowercase` Number of lowercase characters.
-    - `digits` Number of digits.
-    - `special` Number of special characters.
+    - `caps` Minimum number of uppercase characters.
+    - `lowercase` Minimum number of lowercase characters.
+    - `digits` Minimum number of digits.
+    - `special` Minimum number of special characters.
+    - Counts are minimums, not exact targets: when `length` exceeds their sum, the generator draws the remainder from all enabled character classes.
   - `value` - Field value
 * `file_ref` - A list containing file reference information:
   - `uid` - File UID

--- a/docs/ephemeral-resources/record.md
+++ b/docs/ephemeral-resources/record.md
@@ -36,10 +36,11 @@ In addition to all arguments above, the following attributes are exported:
   - `enforce_generation` - Enforce generation flag (for password field)
   - `complexity` - A list containing password complexity information
     - `length` - Minimum Password length.
-    - `caps` Number of uppercase characters.
-    - `lowercase` Number of lowercase characters.
-    - `digits` Number of digits.
-    - `special` Number of special characters.
+    - `caps` Minimum number of uppercase characters.
+    - `lowercase` Minimum number of lowercase characters.
+    - `digits` Minimum number of digits.
+    - `special` Minimum number of special characters.
+    - Counts are minimums, not exact targets: when `length` exceeds their sum, the generator draws the remainder from all enabled character classes.
   - `value` - Field value
 * `custom` - A list containing custom fields information:
   - `type` - Field type
@@ -49,10 +50,11 @@ In addition to all arguments above, the following attributes are exported:
   - `enforce_generation` - Enforce generation flag (for password field)
   - `complexity` - A list containing password complexity information
     - `length` - Minimum Password length.
-    - `caps` Number of uppercase characters.
-    - `lowercase` Number of lowercase characters.
-    - `digits` Number of digits.
-    - `special` Number of special characters.
+    - `caps` Minimum number of uppercase characters.
+    - `lowercase` Minimum number of lowercase characters.
+    - `digits` Minimum number of digits.
+    - `special` Minimum number of special characters.
+    - Counts are minimums, not exact targets: when `length` exceeds their sum, the generator draws the remainder from all enabled character classes.
   - `value` - Field value
 * `file_ref` - A list containing file reference information:
   - `uid` - File UID

--- a/docs/resources/bank_account.md
+++ b/docs/resources/bank_account.md
@@ -228,11 +228,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--totp"></a>
 ### Nested Schema for `totp`

--- a/docs/resources/database_credentials.md
+++ b/docs/resources/database_credentials.md
@@ -173,11 +173,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/docs/resources/health_insurance.md
+++ b/docs/resources/health_insurance.md
@@ -183,11 +183,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--url"></a>
 ### Nested Schema for `url`

--- a/docs/resources/login.md
+++ b/docs/resources/login.md
@@ -134,11 +134,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--totp"></a>
 ### Nested Schema for `totp`

--- a/docs/resources/membership.md
+++ b/docs/resources/membership.md
@@ -153,11 +153,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/docs/resources/pam_machine.md
+++ b/docs/resources/pam_machine.md
@@ -136,11 +136,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Passphrase length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during passphrase generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/docs/resources/pam_user.md
+++ b/docs/resources/pam_user.md
@@ -138,11 +138,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Passphrase length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during passphrase generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/docs/resources/passport.md
+++ b/docs/resources/passport.md
@@ -241,11 +241,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/docs/resources/server_credentials.md
+++ b/docs/resources/server_credentials.md
@@ -151,11 +151,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/docs/resources/ssh_keys.md
+++ b/docs/resources/ssh_keys.md
@@ -221,11 +221,14 @@ Read-Only:
 
 Optional:
 
-- **caps** (Number) Number of uppercase characters.
-- **digits** (Number) Number of digits.
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
 - **length** (Number) Password length.
-- **lowercase** (Number) Number of lowercase characters.
-- **special** (Number) Number of special characters.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--custom"></a>
 ### Nested Schema for `custom`

--- a/secretsmanager/record_fields_pam.go
+++ b/secretsmanager/record_fields_pam.go
@@ -541,22 +541,22 @@ func schemaPrivateKeyPassphraseField() *schema.Schema {
 							"caps": {
 								Type:        schema.TypeInt,
 								Optional:    true,
-								Description: "Number of uppercase characters.",
+								Description: "Minimum number of uppercase characters.",
 							},
 							"lowercase": {
 								Type:        schema.TypeInt,
 								Optional:    true,
-								Description: "Number of lowercase characters.",
+								Description: "Minimum number of lowercase characters.",
 							},
 							"digits": {
 								Type:        schema.TypeInt,
 								Optional:    true,
-								Description: "Number of digits.",
+								Description: "Minimum number of digits.",
 							},
 							"special": {
 								Type:        schema.TypeInt,
 								Optional:    true,
-								Description: "Number of special characters.",
+								Description: "Minimum number of special characters.",
 							},
 							"special_set": {
 								Type:        schema.TypeString,


### PR DESCRIPTION
## Summary

QA of REL-4790 found that KSM-1071 shipped incomplete and KSM-990 shipped undocumented. This PR finishes both.

KSM-1071's fix (`9a38550`) changed 8 `Description` strings in `record_fields.go` and one CHANGELOG line, and stopped there. Two things it did not reach:

* `record_fields_pam.go` -> `schemaPrivateKeyPassphraseField()` still described the four counts as exact. That block backs `resource_pam_user.go` and `resource_pam_machine.go`.
* The entire `docs/` tree: 56 count lines across 12 files. Since `docs/` is hand-maintained here (no tfplugindocs, no `go:generate`, no `templates/`, no Makefile docs target) and is what publishes to the Terraform Registry, the documentation bug KSM-1071 was filed to fix was still live for users. The Go `Description` strings that were fixed surface only through `terraform providers schema -json`.

Separately, `special_set` (KSM-990's headline attribute) appeared in **zero** of the 10 resource docs whose complexity block supports it. It existed only in CHANGELOG.md.

## Changes

1. **`record_fields_pam.go`**: 4 descriptions to "Minimum number of ...". The two schema files are now at parity, 12 sites, no bare "Number of" left.
2. **56 doc lines across 12 files** reworded to "Minimum number of ...".
3. **`special_set` added to the 10 resource complexity blocks**, wording taken verbatim from the backing schema: "password generation" for `schemaPasswordField`, "passphrase generation" for `schemaPrivateKeyPassphraseField`.
4. **One note per complexity block, 14 total**, explaining that the generator draws the remainder from all enabled classes when `length` exceeds the sum of the counts.

`data-sources/record.md` and `ephemeral-resources/record.md` deliberately do **not** gain `special_set`. Both are backed by `schemaGenericField()`, which serves read-only record reads where a generation-time option does not apply.

Documentation and schema descriptions only. No behavioral code changes.

## Empirical validation

The wording is not a guess. Live E2E against the QA vault on this build, `terraform apply` with the provider installed from a local mirror, reading values from `terraform.tfstate` rather than `terraform output`:

| Case | Configured | Observed | Conclusion |
| --- | --- | --- | --- |
| `length=20, special=2`, other categories unset | 2 | 3, 3, 2, 3, 3 | minimum, not exact |
| `length=8`, all four categories `=2` (sum equals length) | 2 each | exactly 2 each, 3/3 samples | exact when fully specified |
| **PAM** `private_key_passphrase`, `length=20, special=2` | 2 | 4, 2, 2 | minimum, not exact |
| `length=32, special=5`, `special_set` unset | 5 | 9, 10, 10, all inside the SDK default set | minimum, and the default set is preserved |

The third row is the one that matters for change 1: the PAM path really does behave as a minimum, so the previous wording was empirically wrong.

The fourth row also independently confirms the correction made in `6e3b679`: two of those three samples contain a literal `"`, so the SDK default set does begin with a double-quote as documented.

Also confirmed on the same run: `special=0` with `length=25` produces zero non-alphanumeric characters across 3/3 samples (KSM-989), and `special_set="!@"` confines every special character to that set across 5/5 samples with the value round-tripping through state (KSM-990, `0fb28ef`).

## Verification

* `go build ./...`, `go vet ./...`, `gofmt -s -l .` all clean on Go 1.26.7.
* Full acceptance regression on this branch: **212 pass, 4 fail, 5 skip**, identical to the pre-change baseline. The 4 failures are the unseeded `tf_acc_test_file` / `tf_acc_test_photo` fixtures, the 5 skips are the KSM-1039 PAM ephemeral data gap. No regressions.
* The 6 acceptance tests covering the v1.4.0 features all pass.

## Related

* KSM-1071, KSM-990, REL-4790
* Targets `release-v1.4.0` so PR #90 picks this up before the release is cut.
