### PR TITLE
docs(pam): document the password.complexity nested schema (KSM-1307)

### DIFF
--- a/docs/resources/pam_machine.md
+++ b/docs/resources/pam_machine.md
@@ -81,7 +81,7 @@ resource "secretsmanager_pam_machine" "ssh_machine" {
 - **notes** (String) The secret notes.
 - **operating_system** (Block List, Max: 1) Text field data. Label: "Operating System".
 - **pam_hostname** (Block List, Max: 1) PAM Hostname field data.
-- **password** (Block List, Max: 1) Password field data.
+- **password** (Block List, Max: 1) Password field data. (see [below for nested schema](#nestedblock--password))
 - **private_key_passphrase** (Block List, Max: 1) Private key passphrase. Stored as a custom field labeled "Private Key Passphrase". When used with key generation, the passphrase encrypts the generated private key. (see [below for nested schema](#nestedblock--private_key_passphrase))
 - **private_pem_key** (Block List, Max: 1) Private PEM Key field data. Stored as a secret field labeled "Private PEM Key". Supports SSH key generation. (see [below for nested schema](#nestedblock--private_pem_key))
 - **provider_group** (Block List, Max: 1) Text field data. Label: "Provider Group".
@@ -97,6 +97,37 @@ resource "secretsmanager_pam_machine" "ssh_machine" {
 ### Read-Only
 
 - **type** (String) The secret type.
+
+<a id="nestedblock--password"></a>
+### Nested Schema for `password`
+
+Optional:
+
+- **complexity** (Block List, Max: 1) Password complexity. (see [below for nested schema](#nestedblock--password--complexity))
+- **enforce_generation** (Boolean) Enforce generation flag.
+- **generate** (String) Flag to force password generation (when set to 'yes' or 'true').
+- **label** (String) Field label.
+- **privacy_screen** (Boolean) Privacy screen flag.
+- **required** (Boolean) Required flag.
+- **value** (String, Sensitive) Field value.
+
+Read-Only:
+
+- **type** (String) Field type.
+
+<a id="nestedblock--password--complexity"></a>
+### Nested Schema for `password.complexity`
+
+Optional:
+
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
+- **length** (Number) Password length.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--private_pem_key"></a>
 ### Nested Schema for `private_pem_key`

--- a/docs/resources/pam_user.md
+++ b/docs/resources/pam_user.md
@@ -86,7 +86,7 @@ resource "secretsmanager_pam_user" "rsa_user" {
 - **login** (Block List, Max: 1) Login field data.
 - **managed** (Block List, Max: 1) Checkbox field data. Label: "Managed".
 - **notes** (String) The secret notes.
-- **password** (Block List, Max: 1) Password field data.
+- **password** (Block List, Max: 1) Password field data. (see [below for nested schema](#nestedblock--password))
 - **private_key_passphrase** (Block List, Max: 1) Private key passphrase. Stored as a custom field labeled "Private Key Passphrase". When used with key generation, the passphrase encrypts the generated private key. (see [below for nested schema](#nestedblock--private_key_passphrase))
 - **private_pem_key** (Block List, Max: 1) Private PEM Key field data. Stored as a secret field labeled "Private PEM Key". Supports SSH key generation. (see [below for nested schema](#nestedblock--private_pem_key))
 - **rotation_scripts** (Block List) Script field data. Label: "Rotation Scripts".
@@ -99,6 +99,37 @@ resource "secretsmanager_pam_user" "rsa_user" {
 ### Read-Only
 
 - **type** (String) The secret type.
+
+<a id="nestedblock--password"></a>
+### Nested Schema for `password`
+
+Optional:
+
+- **complexity** (Block List, Max: 1) Password complexity. (see [below for nested schema](#nestedblock--password--complexity))
+- **enforce_generation** (Boolean) Enforce generation flag.
+- **generate** (String) Flag to force password generation (when set to 'yes' or 'true').
+- **label** (String) Field label.
+- **privacy_screen** (Boolean) Privacy screen flag.
+- **required** (Boolean) Required flag.
+- **value** (String, Sensitive) Field value.
+
+Read-Only:
+
+- **type** (String) Field type.
+
+<a id="nestedblock--password--complexity"></a>
+### Nested Schema for `password.complexity`
+
+Optional:
+
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
+- **length** (Number) Password length.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--private_pem_key"></a>
 ### Nested Schema for `private_pem_key`


### PR DESCRIPTION
## Summary

`docs/resources/pam_user.md` and `docs/resources/pam_machine.md` both declared a password block:

```
- **password** (Block List, Max: 1) Password field data.
```

with no nested-schema link and no corresponding section. The only complexity block either file documented was `private_key_passphrase.complexity`. So the password generation options for both PAM resources were undocumented on the Terraform Registry.

The attributes were never missing from the provider. `resource_pam_user.go:56` and `resource_pam_machine.go:59` both wire `password` to `schemaPasswordField("")`, which supports `length`, `caps`, `lowercase`, `digits`, `special` and `special_set`. They were simply undiscoverable.

## Changes

For both files:

1. Linked the `password` bullet to its nested schema, matching how `private_key_passphrase` and `private_pem_key` are already linked in the same list.
2. Added a `Nested Schema for password` section.
3. Added a `Nested Schema for password.complexity` section.

Content is taken verbatim from the eight other password-bearing resource docs, `special_set` and the minimums note included, so all ten now read identically. Sections are inserted in the order the attribute list uses, ahead of `private_pem_key`.

Documentation only. No schema or behavior changes.

## Why this is stacked on #96

Base is `KSM-1071-complexity-docs` rather than `release-v1.4.0`, because the new sections must match the wording that #96 establishes: "Minimum number of ...", the `special_set` entry, and the minimums note. Basing this on `release-v1.4.0` would either duplicate that work or land text inconsistent with the other eight docs.

GitHub will retarget this PR to `release-v1.4.0` automatically when #96 merges. Merge #96 first.

## Scope

Pre-existing gap. Not introduced by any v1.4.0 ticket, and deliberately excluded from the KSM-1071 and KSM-990 documentation pass so that a release-branch PR stayed scoped to what v1.4.0 actually changed. Found while auditing complexity-block documentation coverage across `docs/` during REL-4790 QA.

`docs/` in this repo is hand-maintained: no tfplugindocs, no `go:generate` directive, no `templates/` directory and no Makefile docs target. This cannot be fixed by regenerating.

## Related

* KSM-1307, REL-4790
