### PR TITLE
fix(password): do not rotate an adopted record's password (KSM-1305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `google.golang.org/grpc` to v1.82.1 from v1.79.3, closing GHSA-hrxh-6v49-42gf
 
 ### Fixed
+- Adopting an existing record into Terraform no longer rotates its generated password. `generate` is never stored in the vault, so after `terraform import` it read back empty and any configuration declaring it looked like a change, which regenerated the secret on the first apply while the plan reported the value unchanged. Declaring `generate` for the first time on a record that already holds a value is now treated as adoption rather than a rotation request; a later change to the flag still rotates (KSM-1305)
 - Fix `special=0` being ignored when password `length` exceeds the sum of category counts (KSM-989)
 - Clarify that `caps`, `lowercase`, `digits`, and `special` in the `complexity` block are minimum counts, not exact targets — the generator may produce more of each character class to satisfy the total `length` (KSM-1071)
 

--- a/secretsmanager/provider.go
+++ b/secretsmanager/provider.go
@@ -2983,14 +2983,32 @@ func ApplyFieldChange(section, name string, d *schema.ResourceData, record *core
 							newg = og.(string)
 						}
 					}
+					oldHasValue := false
 					if oldf != nil && len(oldf.([]interface{})) > 0 {
 						if fmap, ok := oldf.([]interface{})[0].(map[string]interface{}); ok {
 							if og, found := fmap["generate"]; found {
 								oldg = og.(string)
 							}
+							if ov, found := fmap["value"]; found {
+								if ovs, ok := ov.(string); ok && ovs != "" {
+									oldHasValue = true
+								}
+							}
 						}
 					}
-					generate = newg != "" && newg != oldg
+					// Regenerate when the generate flag changes to a non-empty value.
+					//
+					// Exception: when there was no previous generate flag and the field
+					// already holds a value, the record is being adopted rather than a
+					// rotation being requested. The clearest case is the first apply
+					// after terraform import, where generate always reads back empty
+					// because it is never persisted to the vault, so any configuration
+					// declaring it looks like a change. Regenerating there replaces a
+					// live credential on a plan that reported the value unchanged.
+					//
+					// This apply still records the flag in state, so a later deliberate
+					// change to it rotates normally.
+					generate = newg != "" && newg != oldg && !(oldg == "" && oldHasValue)
 				}
 			}
 			if field, err := NewFieldFromSchema(recordFieldName, fieldData); err != nil {

--- a/secretsmanager/resource_login_test.go
+++ b/secretsmanager/resource_login_test.go
@@ -474,3 +474,108 @@ func TestAccResourceLogin_import(t *testing.T) {
 		},
 	})
 }
+
+// TestAccResourceLogin_adoptedValueIsNotRegenerated covers KSM-1305: a record that
+// already holds a value must not have that value replaced merely because the
+// configuration has started declaring generate.
+//
+// The condition under test is the one terraform import creates. "generate" is never
+// persisted to the vault, so after an import the flag reads back empty while the password
+// value is present, and any configuration declaring generate therefore looks like a
+// change. Reaching that state through import inside the acceptance framework is awkward,
+// because an ImportState step verifies against a throwaway state rather than continuing
+// with it, so this test reproduces the same code path by starting from a literal value
+// and then adding the flag.
+//
+// Step 1 establishes a literal value with no generate flag.
+// Step 2 declares generate for the first time, so the existing value must be preserved.
+// Step 3 changes the flag again, which is an unambiguous rotation request, so the value
+// must change.
+func TestAccResourceLogin_adoptedValueIsNotRegenerated(t *testing.T) {
+	secretType := "login"
+	secretFolderUid := testAcc.getTestFolder()
+	secretUid := core.GenerateUid()
+	_, secretTitle := testAcc.getRecordInfo(secretType)
+	if secretUid == "" || secretTitle == "" {
+		t.Fatal("Failed to access test data - missing secret UID and/or Title")
+	}
+	secretTitle += "_resource_adopted_value"
+
+	const literal = "AdoptedLiteralValue123"
+
+	configLiteral := fmt.Sprintf(`
+		resource "secretsmanager_login" "%v" {
+			folder_uid = "%v"
+			uid = "%v"
+			title = "%v"
+			password {
+				value = "%v"
+			}
+		}
+	`, secretTitle, secretFolderUid, secretUid, secretTitle, literal)
+
+	configGenerateTemplate := `
+		resource "secretsmanager_login" "%v" {
+			folder_uid = "%v"
+			uid = "%v"
+			title = "%v"
+			password {
+				generate = "%v"
+				complexity {
+					length  = 25
+					special = 0
+				}
+			}
+		}
+	`
+	configAdopt := fmt.Sprintf(configGenerateTemplate, secretTitle, secretFolderUid, secretUid, secretTitle, "yes")
+	configRotate := fmt.Sprintf(configGenerateTemplate, secretTitle, secretFolderUid, secretUid, secretTitle, "true")
+
+	resourceName := fmt.Sprintf("secretsmanager_login.%v", secretTitle)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		PreCheck:                 testAccPreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				Config: configLiteral,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "password.0.value", literal),
+				),
+			},
+			{
+				// generate is declared for the first time on a record that already holds
+				// a value. This is adoption, not a rotation request, so the stored secret
+				// must survive untouched.
+				Config: configAdopt,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretResourceState(resourceName, func(s *terraform.InstanceState) error {
+						if pwd := s.Attributes["password.0.value"]; pwd != literal {
+							return fmt.Errorf("adopting a record must not regenerate its value: expected %q, got %q", literal, pwd)
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				// The flag changes from a recorded value, so this is an explicit rotation.
+				Config: configRotate,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretResourceState(resourceName, func(s *terraform.InstanceState) error {
+						pwd := s.Attributes["password.0.value"]
+						if pwd == literal {
+							return fmt.Errorf("changing the generate flag on an adopted record must rotate the value, but it is unchanged")
+						}
+						if len(pwd) != 25 {
+							return fmt.Errorf("expected a 25-char generated password after rotation, got %d chars", len(pwd))
+						}
+						if strings.ContainsAny(pwd, "\"!@#$%()+;<>=?[]{}^.,") {
+							return fmt.Errorf("expected no special characters with special = 0, got %q", pwd)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adopting an existing generated-password record into Terraform rotated the credential on the first apply, and the plan did not disclose it.

The plan showed only the `generate` flag being added and reported the password value among the unchanged attributes it was hiding:

```
      ~ password {
          + generate           = "yes"
            # (6 unchanged attributes hidden)
        }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Applying that plan replaced the stored password. Measured by SHA-256 of the value in `terraform.tfstate`, `4854472b…` became `3f7d6fa5…`, and the result reproduced on a second independent record. A plan that reports a value as unchanged must not change it, least of all a live credential.

## Root cause

Regeneration is gated in `ApplyFieldChange` on a **raw string** comparison:

```go
generate = newg != "" && newg != oldg
```

`generate` is never persisted to the vault record, so after `terraform import` it reads back as `""` while the password value is present. Any configuration declaring `generate` therefore looks like a change, the gate fires, and the secret is replaced. Confirmed directly: `generate` in state immediately after import is `''`.

This affects every password-bearing and passphrase-bearing resource, since they all route through the same function.

## The fix

One exception is added to the gate: when there was no previous `generate` flag **and** the field already holds a value, the record is being adopted rather than a rotation being requested, so the stored secret is left alone.

```go
generate = newg != "" && newg != oldg && !(oldg == "" && oldHasValue)
```

The apply still records the flag in state, so a later deliberate change to it rotates normally. There is no dead end.

## Verified end to end

Against the QA vault, reading values from `terraform.tfstate` rather than `terraform output`:

| Scenario | Expected | Result |
| --- | --- | --- |
| Create with `generate = "yes"` | generates | 25-char password generated, **PASS** |
| **Import, then reconcile apply** | value preserved | `ad672045…` unchanged, **PASS** (previously rotated) |
| Flip `generate` "yes" to "true" afterwards | rotates | `ad672045…` to `f997689c…`, **PASS** |
| Re-apply unchanged config | no rotation | unchanged, idempotent, **PASS** |
| Literal value, then add `generate` | value preserved | preserved, **not wiped**, flag recorded |

## The behavior change a reviewer should weigh

That last row is the trade-off. Adding `generate` to a record that already holds a value no longer generates on that same apply; it takes effect on the next change to the flag.

Two things make this acceptable rather than a regression:

* The existing value is **preserved, not wiped**. I tested this specifically, because a fix that silently emptied a password field would be far worse than the bug.
* Rotation stays reachable. The flag is recorded on the adoption apply, so changing it afterwards rotates as normal. The failure mode is one extra apply, not a lost secret.

The alternative fixes were considered and rejected:

* **Disclose the rotation in the plan instead.** This is what I tried first, using `CustomizeDiff` with `SetNewComputed`. It is not possible in SDKv2 without a schema change. `SetNewComputed("password.0.value")` fails with `invalid key`, because nested keys are unsupported, and `SetNewComputed("password")` fails with `SetNewComputed only operates on computed keys - password is not one`. Disclosure would require making the sensitive value `Optional + Computed`, which changes drift detection on a secret and is a much larger change than this one.
* **Reject the apply at plan time.** Safe and loud, but it breaks the adopt-then-reconcile workflow entirely, since the user could never apply while `generate` is in the configuration.

## Release timing

This targets `release-v1.4.0` for consistency with the other QA fixes, but it is a **behavior change on a pre-existing defect**, not a v1.4.0 regression. If you would rather not move credential-rotation semantics on a branch that has already been through QA, retargeting this at `master` for 1.4.1 is entirely reasonable. The other two QA PRs, #96 and #97, are documentation only and carry no such question.

## Verification

* `go build ./...`, `go vet ./...`, `gofmt -s -l .` clean on Go 1.26.7.
* Full acceptance suite: only the four pre-existing `tf_acc_test_file` and `tf_acc_test_photo` fixture failures, which need an attachment UID the provider cannot create. No new failures.
* `TestAccResourceLogin_adoptedValueIsNotRegenerated` added. It reproduces the import condition through a literal value followed by a `generate` flag, since an `ImportState` step verifies against a throwaway state and cannot continue with it.

**The new test was verified to have teeth.** Reverting the gate to its previous form makes it fail at step 2 with:

```
adopting a record must not regenerate its value:
expected "AdoptedLiteralValue123", got "lMvKnRYH1tWCdhFCuq3r2dwi4"
```

## Related

* KSM-1305, REL-4790
* KSM-1306 shares the same gate but is test coverage only, in #98.
