### PR TITLE
docs(pam): re-land the password.complexity nested schema on the release branch (KSM-1307)

### DIFF
--- a/docs/resources/pam_machine.md
+++ b/docs/resources/pam_machine.md
@@ -81,7 +81,7 @@ resource "secretsmanager_pam_machine" "ssh_machine" {
 - **notes** (String) The secret notes.
 - **operating_system** (Block List, Max: 1) Text field data. Label: "Operating System".
 - **pam_hostname** (Block List, Max: 1) PAM Hostname field data.
-- **password** (Block List, Max: 1) Password field data.
+- **password** (Block List, Max: 1) Password field data. (see [below for nested schema](#nestedblock--password))
 - **private_key_passphrase** (Block List, Max: 1) Private key passphrase. Stored as a custom field labeled "Private Key Passphrase". When used with key generation, the passphrase encrypts the generated private key. (see [below for nested schema](#nestedblock--private_key_passphrase))
 - **private_pem_key** (Block List, Max: 1) Private PEM Key field data. Stored as a secret field labeled "Private PEM Key". Supports SSH key generation. (see [below for nested schema](#nestedblock--private_pem_key))
 - **provider_group** (Block List, Max: 1) Text field data. Label: "Provider Group".
@@ -97,6 +97,37 @@ resource "secretsmanager_pam_machine" "ssh_machine" {
 ### Read-Only
 
 - **type** (String) The secret type.
+
+<a id="nestedblock--password"></a>
+### Nested Schema for `password`
+
+Optional:
+
+- **complexity** (Block List, Max: 1) Password complexity. (see [below for nested schema](#nestedblock--password--complexity))
+- **enforce_generation** (Boolean) Enforce generation flag.
+- **generate** (String) Flag to force password generation (when set to 'yes' or 'true').
+- **label** (String) Field label.
+- **privacy_screen** (Boolean) Privacy screen flag.
+- **required** (Boolean) Required flag.
+- **value** (String, Sensitive) Field value.
+
+Read-Only:
+
+- **type** (String) Field type.
+
+<a id="nestedblock--password--complexity"></a>
+### Nested Schema for `password.complexity`
+
+Optional:
+
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
+- **length** (Number) Password length.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--private_pem_key"></a>
 ### Nested Schema for `private_pem_key`

--- a/docs/resources/pam_user.md
+++ b/docs/resources/pam_user.md
@@ -86,7 +86,7 @@ resource "secretsmanager_pam_user" "rsa_user" {
 - **login** (Block List, Max: 1) Login field data.
 - **managed** (Block List, Max: 1) Checkbox field data. Label: "Managed".
 - **notes** (String) The secret notes.
-- **password** (Block List, Max: 1) Password field data.
+- **password** (Block List, Max: 1) Password field data. (see [below for nested schema](#nestedblock--password))
 - **private_key_passphrase** (Block List, Max: 1) Private key passphrase. Stored as a custom field labeled "Private Key Passphrase". When used with key generation, the passphrase encrypts the generated private key. (see [below for nested schema](#nestedblock--private_key_passphrase))
 - **private_pem_key** (Block List, Max: 1) Private PEM Key field data. Stored as a secret field labeled "Private PEM Key". Supports SSH key generation. (see [below for nested schema](#nestedblock--private_pem_key))
 - **rotation_scripts** (Block List) Script field data. Label: "Rotation Scripts".
@@ -99,6 +99,37 @@ resource "secretsmanager_pam_user" "rsa_user" {
 ### Read-Only
 
 - **type** (String) The secret type.
+
+<a id="nestedblock--password"></a>
+### Nested Schema for `password`
+
+Optional:
+
+- **complexity** (Block List, Max: 1) Password complexity. (see [below for nested schema](#nestedblock--password--complexity))
+- **enforce_generation** (Boolean) Enforce generation flag.
+- **generate** (String) Flag to force password generation (when set to 'yes' or 'true').
+- **label** (String) Field label.
+- **privacy_screen** (Boolean) Privacy screen flag.
+- **required** (Boolean) Required flag.
+- **value** (String, Sensitive) Field value.
+
+Read-Only:
+
+- **type** (String) Field type.
+
+<a id="nestedblock--password--complexity"></a>
+### Nested Schema for `password.complexity`
+
+Optional:
+
+- **caps** (Number) Minimum number of uppercase characters.
+- **digits** (Number) Minimum number of digits.
+- **length** (Number) Password length.
+- **lowercase** (Number) Minimum number of lowercase characters.
+- **special** (Number) Minimum number of special characters.
+- **special_set** (String) Custom set of special characters to draw from during password generation. Empty string uses the SDK default set `"!@#$%()+;<>=?[]{}^.,` (note the leading double-quote).
+
+The `caps`, `lowercase`, `digits`, and `special` counts are minimums, not exact targets. When `length` exceeds their sum, the generator draws the remaining characters from all enabled character classes, so a class may appear more times than its configured count.
 
 <a id="nestedblock--private_pem_key"></a>
 ### Nested Schema for `private_pem_key`


### PR DESCRIPTION
## Why this PR exists

PR #97 merged, but its content never reached `release-v1.4.0`. This re-lands it.

#97 was based on `KSM-1071-complexity-docs`, the branch behind #96, because its new sections had to match the wording #96 establishes. The merge order then went the wrong way:

| Time | Event | Effect |
| --- | --- | --- |
| 19:16:31 | #96 merged `KSM-1071-complexity-docs` into `release-v1.4.0` | that branch was consumed |
| 19:16:52 | #97 merged into `KSM-1071-complexity-docs` | landed on a branch that no longer feeds the release |

So `d347df99`, #97's merge commit, is not an ancestor of `release-v1.4.0`, and both PAM docs still had **zero** `password.complexity` sections on the release branch. Confirmed with `git merge-base --is-ancestor`.

My earlier advice that GitHub would retarget #97 automatically was wrong. Auto-retargeting happens when a base branch is **deleted** on merge; merging #96 did not delete `KSM-1071-complexity-docs`, so #97 stayed pointed at it. Merging #97 first, or retargeting it manually after #96, would have avoided this.

## Contents

A clean cherry-pick of `f96a8c4` onto `release-v1.4.0`, unchanged. For both `pam_user.md` and `pam_machine.md`:

1. Linked the `password` bullet to its nested schema, matching how `private_key_passphrase` and `private_pem_key` are already linked in the same list.
2. Added a `Nested Schema for password` section.
3. Added a `Nested Schema for password.complexity` section.

Cherry-picked with no conflicts.

## Verification

All ten password-bearing resource docs are now consistent:

| Doc | Complexity blocks documented | `special_set` entries |
| --- | --- | --- |
| login, bank_account, passport, membership, health_insurance, database_credentials, server_credentials, ssh_keys | 1 | 1 |
| pam_user, pam_machine | **2** | **2** |

The PAM files legitimately carry two, because both resources expose `password` and `private_key_passphrase`, each with its own complexity block. Before this change they documented only the passphrase one.

`go build ./...` and `gofmt -s -l .` clean. Documentation only, no schema or behavior changes.

## Related

* KSM-1307, REL-4790
* Supersedes #97, which should be closed as landed-elsewhere rather than reopened.
